### PR TITLE
feat(web): align office wall fixtures and expand windows/plants

### DIFF
--- a/web/src/components/canvas/Office.tsx
+++ b/web/src/components/canvas/Office.tsx
@@ -137,11 +137,13 @@ function Bookshelf({
 
 function MonitorWall({
   position,
+  rotation = [0, 0, 0],
 }: {
   position: [number, number, number];
+  rotation?: [number, number, number];
 }) {
   return (
-    <group position={position}>
+    <group position={position} rotation={rotation}>
       {Array.from({ length: 6 }).map((_, i) => {
         const row = Math.floor(i / 3);
         const col = i % 3;
@@ -507,8 +509,8 @@ export function Office() {
         </group>
       )}
 
-      {/* Monitor wall */}
-      <MonitorWall position={[10.8, 0, -3]} />
+      {/* Monitor wall mounted flush on right wall */}
+      <MonitorWall position={[10.88, 0, -5]} rotation={[0, -Math.PI / 2, 0]} />
 
       {/* Task board */}
       <TaskBoard position={[0, 1.8, -13.85]} />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Purely visual/layout changes to a single canvas component; no data flow, auth, or backend logic impacted.
> 
> **Overview**
> Adjusts the 3D `Office` scene so the monitor wall can be rotated and is repositioned to sit flush on the right wall.
> 
> `MonitorWall` now accepts an optional `rotation` prop (defaulting to no rotation), and the `Office` placement updates the monitor wall position and rotates it by 90° to align with the right-side wall plane.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a13ed896b1ed653e6fb4865fd1a0ba859f687d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->