### PR TITLE
fix(web): keep manual agent actions visible and pin docs sidebar

### DIFF
--- a/web/src/app/docs/layout.tsx
+++ b/web/src/app/docs/layout.tsx
@@ -8,6 +8,9 @@ export default function Layout({ children }: { children: ReactNode }) {
     <RootProvider theme={{ enabled: false }}>
       <DocsLayout
         tree={source.pageTree}
+        sidebar={{
+          collapsible: false,
+        }}
         containerProps={{
           style: {
             "--fd-layout-width": "100dvw",

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -164,3 +164,11 @@ a {
   -webkit-user-select: none;
   user-select: none;
 }
+
+/* Keep docs sidebar pinned on desktop even if upstream sticky var classes fail to apply. */
+#nd-docs-layout [data-sidebar-placeholder] {
+  position: sticky;
+  top: var(--fd-docs-row-1, 0px);
+  align-self: start;
+  height: calc(100dvh - var(--fd-docs-row-1, 0px));
+}

--- a/web/src/components/ui/HUD.tsx
+++ b/web/src/components/ui/HUD.tsx
@@ -7,6 +7,7 @@ import { STATUS_LABELS, AGENT_COLORS } from "@/types";
 import type { AgentStatus } from "@/types";
 import type { CelebrationType } from "@/types";
 import { AGENT_SPACE_RELEASES_URL } from "@/lib/downloads";
+import { setManualAgentOverride } from "@/lib/simulation";
 import { Minimap } from "./Minimap";
 
 const STATUS_COLOR: Record<AgentStatus, string> = {
@@ -285,6 +286,7 @@ function TopBar({
       }
 
       selectAgent(target.id);
+      setManualAgentOverride(target.id, task, status);
       updateAgent(target.id, { status, currentTask: task });
       showToast(toastMessage, "success");
     },


### PR DESCRIPTION
## Summary
- preserve manual menu-driven agent task/status updates for a timed window so simulation does not overwrite them immediately
- wire HUD manual actions into simulation via `setManualAgentOverride`
- disable docs sidebar collapsing to keep it fixed-open on desktop
- add a CSS safety override to keep the docs sidebar placeholder sticky

## Validation
- pnpm lint:web
- pnpm -C web exec tsc --noEmit
- pnpm -C web build
- git hooks also ran full lint/typecheck/build on commit/push

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, UI-focused changes plus a localized simulation-state override map; main risk is minor timing/state inconsistencies in agent status/task rendering.
> 
> **Overview**
> Manual agent actions from the HUD now set a timed override via new `setManualAgentOverride`, and `simulateStep` respects that override for status/task updates (with expiry) instead of immediately reverting to scripted simulation output.
> 
> Docs layout is adjusted to keep the sidebar fixed-open (`collapsible: false`), with a global CSS sticky fallback for the sidebar placeholder to remain pinned on desktop.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c96ee15903a1ba11dabc59126329577badb2a15c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->