### PR TITLE
chore: define Node runtime and @types/node policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,68 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
+    groups:
+      npm-root-nonbreaking:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+      - dependency-name: "@types/node"
+        update-types:
+          - version-update:semver-major
+      - dependency-name: "three"
+        update-types:
+          - version-update:semver-minor
+      - dependency-name: "@types/three"
+        update-types:
+          - version-update:semver-minor
+      - dependency-name: "@xterm/addon-fit"
+        update-types:
+          - version-update:semver-minor
   - package-ecosystem: npm
     directory: "/web"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
+    groups:
+      npm-web-nonbreaking:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+      - dependency-name: "@types/node"
+        update-types:
+          - version-update:semver-major
+      - dependency-name: "three"
+        update-types:
+          - version-update:semver-minor
+      - dependency-name: "@types/three"
+        update-types:
+          - version-update:semver-minor
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      github-actions-nonbreaking:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies
@@ -99,7 +99,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,12 @@ Thanks for contributing.
 
 Prerequisites:
 
-- Node.js 20.x to 22.x (22.x recommended)
+- Node.js 22.x
 - pnpm 10.12.4
+
+Runtime and types policy:
+
+- [`docs/engineering/node-runtime-types-policy.md`](./docs/engineering/node-runtime-types-policy.md)
 
 Install:
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Agent Observer is a desktop-first observability workspace for AI agents, with a 
 
 ## Prerequisites
 
-- Node.js 20.x to 22.x (22.x recommended)
+- Node.js 22.x
 - pnpm 10.12.4
 - macOS (Apple Silicon) for packaged desktop artifacts
 
@@ -65,6 +65,7 @@ pnpm -C web dev
 ## Contributing and Community
 
 - Contributing guide: [`CONTRIBUTING.md`](./CONTRIBUTING.md)
+- Runtime and Node types policy: [`docs/engineering/node-runtime-types-policy.md`](./docs/engineering/node-runtime-types-policy.md)
 - Code of conduct: [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md)
 - Security policy: [`SECURITY.md`](./SECURITY.md)
 - Support guide: [`SUPPORT.md`](./SUPPORT.md)

--- a/docs/engineering/node-runtime-types-policy.md
+++ b/docs/engineering/node-runtime-types-policy.md
@@ -1,0 +1,36 @@
+# Node Runtime and Type Policy
+
+This project standardizes on **Node.js 22.x** for local development, CI, and production usage.
+
+## Source of Truth
+
+- `.nvmrc` defines the default local Node version.
+- `engines.node` in:
+  - `package.json`
+  - `web/package.json`
+- GitHub Actions CI uses `.nvmrc` via `actions/setup-node`.
+
+All three must stay aligned.
+
+## `@types/node` Policy
+
+- `@types/node` must stay on major `22`.
+- Minor and patch updates within major `22` are allowed through normal dependency maintenance.
+- Major upgrades (for example, `22 -> 23`) are treated as a planned refactor, not an automatic dependency bump.
+
+## Dependabot Policy
+
+- Dependabot major-version updates are ignored by default.
+- `@types/node` major updates are explicitly ignored to keep runtime and type upgrades intentional and coordinated.
+
+## Upgrade Procedure for Next Node Major
+
+When moving from Node 22 to the next major:
+
+1. Open a tracking issue describing runtime, CI, and dependency impact.
+2. Update `.nvmrc`.
+3. Update `engines.node` in both `package.json` files.
+4. Update `@types/node` in all workspaces that reference Node APIs.
+5. Update CI and any release/build scripts that assume a Node major.
+6. Run full CI (desktop checks, frontend checks, and smoke where applicable).
+7. Document the change in `CHANGELOG.md`.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/webrenew/agent-space#readme",
   "engines": {
-    "node": ">=20 <23",
+    "node": ">=22 <23",
     "pnpm": ">=10.12.4"
   },
   "pnpm": {
@@ -63,6 +63,7 @@
     "@electron/rebuild": "^4.0.3",
     "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4.1.18",
+    "@types/node": "^22.19.11",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
     "@types/three": "^0.175.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@memories.sh/cli':
         specifier: ^0.7.6
-        version: 0.7.6(@types/node@25.2.3)(encoding@0.1.13)
+        version: 0.7.6(@types/node@22.19.11)(encoding@0.1.13)
       '@modelcontextprotocol/sdk':
         specifier: ^1.26.0
         version: 1.26.0(zod@4.3.6)
@@ -69,6 +69,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.1.18
         version: 4.1.18
+      '@types/node':
+        specifier: ^22.19.11
+        version: 22.19.11
       '@types/react':
         specifier: ^19.1.0
         version: 19.2.14
@@ -92,7 +95,7 @@ importers:
         version: 26.7.0(electron-builder-squirrel-windows@26.7.0)
       electron-vite:
         specifier: ^3.1.0
-        version: 3.1.0(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+        version: 3.1.0(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
@@ -164,7 +167,7 @@ importers:
         specifier: ^4.1.0
         version: 4.1.18
       '@types/node':
-        specifier: ^22.0.0
+        specifier: ^22.19.11
         version: 22.19.11
       '@types/react':
         specifier: ^19.1.0
@@ -2023,9 +2026,6 @@ packages:
 
   '@types/node@24.10.13':
     resolution: {integrity: sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==}
-
-  '@types/node@25.2.3':
-    resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
 
   '@types/offscreencanvas@2019.7.3':
     resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
@@ -6757,122 +6757,122 @@ snapshots:
 
   '@inquirer/ansi@2.0.3': {}
 
-  '@inquirer/checkbox@5.0.6(@types/node@25.2.3)':
+  '@inquirer/checkbox@5.0.6(@types/node@22.19.11)':
     dependencies:
       '@inquirer/ansi': 2.0.3
-      '@inquirer/core': 11.1.3(@types/node@25.2.3)
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
       '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@25.2.3)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 25.2.3
+      '@types/node': 22.19.11
 
-  '@inquirer/confirm@6.0.6(@types/node@25.2.3)':
+  '@inquirer/confirm@6.0.6(@types/node@22.19.11)':
     dependencies:
-      '@inquirer/core': 11.1.3(@types/node@25.2.3)
-      '@inquirer/type': 4.0.3(@types/node@25.2.3)
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 25.2.3
+      '@types/node': 22.19.11
 
-  '@inquirer/core@11.1.3(@types/node@25.2.3)':
+  '@inquirer/core@11.1.3(@types/node@22.19.11)':
     dependencies:
       '@inquirer/ansi': 2.0.3
       '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@25.2.3)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
       cli-width: 4.1.0
       fast-wrap-ansi: 0.2.0
       mute-stream: 3.0.0
       signal-exit: 4.1.0
     optionalDependencies:
-      '@types/node': 25.2.3
+      '@types/node': 22.19.11
 
-  '@inquirer/editor@5.0.6(@types/node@25.2.3)':
+  '@inquirer/editor@5.0.6(@types/node@22.19.11)':
     dependencies:
-      '@inquirer/core': 11.1.3(@types/node@25.2.3)
-      '@inquirer/external-editor': 2.0.3(@types/node@25.2.3)
-      '@inquirer/type': 4.0.3(@types/node@25.2.3)
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/external-editor': 2.0.3(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 25.2.3
+      '@types/node': 22.19.11
 
-  '@inquirer/expand@5.0.6(@types/node@25.2.3)':
+  '@inquirer/expand@5.0.6(@types/node@22.19.11)':
     dependencies:
-      '@inquirer/core': 11.1.3(@types/node@25.2.3)
-      '@inquirer/type': 4.0.3(@types/node@25.2.3)
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 25.2.3
+      '@types/node': 22.19.11
 
-  '@inquirer/external-editor@2.0.3(@types/node@25.2.3)':
+  '@inquirer/external-editor@2.0.3(@types/node@22.19.11)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 25.2.3
+      '@types/node': 22.19.11
 
   '@inquirer/figures@2.0.3': {}
 
-  '@inquirer/input@5.0.6(@types/node@25.2.3)':
+  '@inquirer/input@5.0.6(@types/node@22.19.11)':
     dependencies:
-      '@inquirer/core': 11.1.3(@types/node@25.2.3)
-      '@inquirer/type': 4.0.3(@types/node@25.2.3)
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 25.2.3
+      '@types/node': 22.19.11
 
-  '@inquirer/number@4.0.6(@types/node@25.2.3)':
+  '@inquirer/number@4.0.6(@types/node@22.19.11)':
     dependencies:
-      '@inquirer/core': 11.1.3(@types/node@25.2.3)
-      '@inquirer/type': 4.0.3(@types/node@25.2.3)
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 25.2.3
+      '@types/node': 22.19.11
 
-  '@inquirer/password@5.0.6(@types/node@25.2.3)':
-    dependencies:
-      '@inquirer/ansi': 2.0.3
-      '@inquirer/core': 11.1.3(@types/node@25.2.3)
-      '@inquirer/type': 4.0.3(@types/node@25.2.3)
-    optionalDependencies:
-      '@types/node': 25.2.3
-
-  '@inquirer/prompts@8.2.1(@types/node@25.2.3)':
-    dependencies:
-      '@inquirer/checkbox': 5.0.6(@types/node@25.2.3)
-      '@inquirer/confirm': 6.0.6(@types/node@25.2.3)
-      '@inquirer/editor': 5.0.6(@types/node@25.2.3)
-      '@inquirer/expand': 5.0.6(@types/node@25.2.3)
-      '@inquirer/input': 5.0.6(@types/node@25.2.3)
-      '@inquirer/number': 4.0.6(@types/node@25.2.3)
-      '@inquirer/password': 5.0.6(@types/node@25.2.3)
-      '@inquirer/rawlist': 5.2.2(@types/node@25.2.3)
-      '@inquirer/search': 4.1.2(@types/node@25.2.3)
-      '@inquirer/select': 5.0.6(@types/node@25.2.3)
-    optionalDependencies:
-      '@types/node': 25.2.3
-
-  '@inquirer/rawlist@5.2.2(@types/node@25.2.3)':
-    dependencies:
-      '@inquirer/core': 11.1.3(@types/node@25.2.3)
-      '@inquirer/type': 4.0.3(@types/node@25.2.3)
-    optionalDependencies:
-      '@types/node': 25.2.3
-
-  '@inquirer/search@4.1.2(@types/node@25.2.3)':
-    dependencies:
-      '@inquirer/core': 11.1.3(@types/node@25.2.3)
-      '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@25.2.3)
-    optionalDependencies:
-      '@types/node': 25.2.3
-
-  '@inquirer/select@5.0.6(@types/node@25.2.3)':
+  '@inquirer/password@5.0.6(@types/node@22.19.11)':
     dependencies:
       '@inquirer/ansi': 2.0.3
-      '@inquirer/core': 11.1.3(@types/node@25.2.3)
-      '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@25.2.3)
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 25.2.3
+      '@types/node': 22.19.11
 
-  '@inquirer/type@4.0.3(@types/node@25.2.3)':
+  '@inquirer/prompts@8.2.1(@types/node@22.19.11)':
+    dependencies:
+      '@inquirer/checkbox': 5.0.6(@types/node@22.19.11)
+      '@inquirer/confirm': 6.0.6(@types/node@22.19.11)
+      '@inquirer/editor': 5.0.6(@types/node@22.19.11)
+      '@inquirer/expand': 5.0.6(@types/node@22.19.11)
+      '@inquirer/input': 5.0.6(@types/node@22.19.11)
+      '@inquirer/number': 4.0.6(@types/node@22.19.11)
+      '@inquirer/password': 5.0.6(@types/node@22.19.11)
+      '@inquirer/rawlist': 5.2.2(@types/node@22.19.11)
+      '@inquirer/search': 4.1.2(@types/node@22.19.11)
+      '@inquirer/select': 5.0.6(@types/node@22.19.11)
     optionalDependencies:
-      '@types/node': 25.2.3
+      '@types/node': 22.19.11
+
+  '@inquirer/rawlist@5.2.2(@types/node@22.19.11)':
+    dependencies:
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
+    optionalDependencies:
+      '@types/node': 22.19.11
+
+  '@inquirer/search@4.1.2(@types/node@22.19.11)':
+    dependencies:
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/figures': 2.0.3
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
+    optionalDependencies:
+      '@types/node': 22.19.11
+
+  '@inquirer/select@5.0.6(@types/node@22.19.11)':
+    dependencies:
+      '@inquirer/ansi': 2.0.3
+      '@inquirer/core': 11.1.3(@types/node@22.19.11)
+      '@inquirer/figures': 2.0.3
+      '@inquirer/type': 4.0.3(@types/node@22.19.11)
+    optionalDependencies:
+      '@types/node': 22.19.11
+
+  '@inquirer/type@4.0.3(@types/node@22.19.11)':
+    optionalDependencies:
+      '@types/node': 22.19.11
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -7019,9 +7019,9 @@ snapshots:
 
   '@mediapipe/tasks-vision@0.10.17': {}
 
-  '@memories.sh/cli@0.7.6(@types/node@25.2.3)(encoding@0.1.13)':
+  '@memories.sh/cli@0.7.6(@types/node@22.19.11)(encoding@0.1.13)':
     dependencies:
-      '@inquirer/prompts': 8.2.1(@types/node@25.2.3)
+      '@inquirer/prompts': 8.2.1(@types/node@22.19.11)
       '@libsql/client': 0.17.0(encoding@0.1.13)
       '@modelcontextprotocol/sdk': 1.26.0(zod@4.3.6)
       '@xenova/transformers': 2.17.2
@@ -7920,11 +7920,6 @@ snapshots:
   '@types/node@24.10.13':
     dependencies:
       undici-types: 7.16.0
-
-  '@types/node@25.2.3':
-    dependencies:
-      undici-types: 7.16.0
-    optional: true
 
   '@types/offscreencanvas@2019.7.3': {}
 
@@ -9044,7 +9039,7 @@ snapshots:
 
   electron-to-chromium@1.5.286: {}
 
-  electron-vite@3.1.0(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)):
+  electron-vite@3.1.0(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
@@ -9052,7 +9047,7 @@ snapshots:
       esbuild: 0.25.12
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -12829,22 +12824,6 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 22.19.11
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.30.2
-      yaml: 2.8.2
-    optional: true
-
-  vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2):
-    dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.57.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 25.2.3
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.30.2

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=20 <23",
+    "node": ">=22 <23",
     "pnpm": ">=10.12.4"
   },
   "scripts": {
@@ -31,7 +31,7 @@
     "@eslint/js": "9.39.1",
     "@next/eslint-plugin-next": "16.1.6",
     "@tailwindcss/postcss": "^4.1.0",
-    "@types/node": "^22.0.0",
+    "@types/node": "^22.19.11",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
     "@types/three": "^0.175.0",


### PR DESCRIPTION
## Summary
- add a documented Node runtime/types policy at `docs/engineering/node-runtime-types-policy.md`
- standardize project Node engines to `>=22 <23` (root + web) and align `@types/node` to `^22.19.11`
- make CI consume `.nvmrc` via `actions/setup-node` to prevent Node version drift
- tighten Dependabot behavior for predictable non-breaking updates, including explicit `@types/node` major ignores

## Validation
- `pnpm lint`
- `pnpm -C web run lint`
- `pnpm typecheck`
- `pnpm -C web exec tsc --noEmit`
- pre-push hooks also passed: `pnpm build` and `pnpm -C web build`

Closes #33

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily config/docs updates to Node version pinning and Dependabot grouping/ignores; minimal runtime impact beyond enforcing Node 22 in local/CI.
> 
> **Overview**
> Standardizes the repo on **Node.js 22.x** by tightening `engines.node` in both `package.json` files, updating `@types/node` to `^22.19.11`, and switching GitHub Actions CI to read the Node version from `.nvmrc`.
> 
> Adds a documented runtime/types policy at `docs/engineering/node-runtime-types-policy.md` and updates contributor docs to reflect it.
> 
> Tightens Dependabot to reduce PR noise and avoid breaking upgrades by lowering PR limits, grouping minor/patch updates, and ignoring major updates by default (with explicit ignores for `@types/node` majors and selected deps like `three` minor bumps).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d4aada75c62c6a458e8b430c3c12f6c23e07f5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->