### PR TITLE
chore: align root react-dom patch with react

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "monaco-editor": "^0.55.1",
     "node-pty": "^1.0.0",
     "react": "^19.2.4",
-    "react-dom": "^19.1.0",
+    "react-dom": "^19.2.4",
     "three": "^0.175.0",
     "typescript-language-server": "^5.1.3",
     "vscode-jsonrpc": "^8.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,7 +39,7 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4
       react-dom:
-        specifier: ^19.1.0
+        specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
       three:
         specifier: ^0.175.0


### PR DESCRIPTION
## Summary
- align root `react-dom` from `^19.1.0` to `^19.2.4` to match `react@^19.2.4`
- refresh lockfile metadata for the aligned root dependency range

## Validation
Passed:
- `pnpm lint`
- `pnpm lint:web`
- `pnpm typecheck`
- `pnpm build`
- `pnpm -C web build`

Smoke status:
- `pnpm test:smoke` currently fails on `Choose folder` visibility in `tests/smoke/desktop.smoke.spec.ts`
- investigation: the UI gate for that button depends on empty chat history and no working directory; the test can load persisted/synced history in current app behavior, so this appears pre-existing and not caused by this dependency-only patch

Closes #30

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency/lockfile-only change aligning `react-dom` patch version; low risk beyond potential patch-level runtime differences in React DOM.
> 
> **Overview**
> Aligns root React dependencies by bumping `react-dom` from `^19.1.0` to `^19.2.4` to match `react@^19.2.4`.
> 
> Updates `pnpm-lock.yaml` accordingly so the resolved `react-dom` version and downstream peer dependency graph reflect the new range.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a65c9c780a713e008285609e0ce0eea996278c0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->