### PR TITLE
chore: bump @xterm/addon-fit to 0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@monaco-editor/react": "^4.7.0",
     "@react-three/drei": "^10.0.0",
     "@react-three/fiber": "^9.1.0",
-    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^5.5.0",
     "monaco-editor": "^0.55.1",
     "node-pty": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^9.1.0
         version: 9.5.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.175.0)
       '@xterm/addon-fit':
-        specifier: ^0.10.0
-        version: 0.10.0(@xterm/xterm@5.5.0)
+        specifier: ^0.11.0
+        version: 0.11.0
       '@xterm/xterm':
         specifier: ^5.5.0
         version: 5.5.0
@@ -2319,10 +2319,8 @@ packages:
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
 
-  '@xterm/addon-fit@0.10.0':
-    resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
-    peerDependencies:
-      '@xterm/xterm': ^5.0.0
+  '@xterm/addon-fit@0.11.0':
+    resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
 
   '@xterm/xterm@5.5.0':
     resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
@@ -8251,9 +8249,7 @@ snapshots:
 
   '@xmldom/xmldom@0.8.11': {}
 
-  '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
-    dependencies:
-      '@xterm/xterm': 5.5.0
+  '@xterm/addon-fit@0.11.0': {}
 
   '@xterm/xterm@5.5.0': {}
 


### PR DESCRIPTION
## Summary
- bump `@xterm/addon-fit` from `^0.10.0` to `^0.11.0`
- update lockfile to the new addon-fit release metadata

## Validation
Passed:
- `pnpm lint`
- `pnpm lint:web`
- `pnpm typecheck`
- `pnpm build`
- `pnpm -C web build`

## Terminal Fit Checklist (documented)
Manual/targeted validation performed with an Electron Playwright script:
- [x] Open app with isolated temp user data directory
- [x] Open `TERMINAL` panel
- [x] Verify xterm instance has non-zero fitted size and row count on startup
- [x] Resize the Electron window
- [x] Verify xterm remains fitted with non-zero size and row count after resize

Observed metrics from run:
- before resize: `{ "width": 654.234375, "height": 774, "rowCount": 43 }`
- after resize: `{ "width": 588.4375, "height": 648, "rowCount": 36 }`

Closes #34

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with lockfile updates; runtime impact is limited to xterm fitting behavior and should be easy to validate in the terminal UI.
> 
> **Overview**
> Updates the terminal fit addon dependency by bumping `@xterm/addon-fit` from `^0.10.0` to `^0.11.0` and refreshes `pnpm-lock.yaml` accordingly (new resolved version/integrity metadata and lock entry shape).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1712b5c8b77ecf8e2d4a33dfdad301e4520f8e10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->