### PR TITLE
ci: upgrade core GitHub Actions to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -28,7 +28,7 @@ jobs:
           version: 10.12.4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -54,7 +54,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -62,7 +62,7 @@ jobs:
           version: 10.12.4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -89,7 +89,7 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -97,7 +97,7 @@ jobs:
           version: 10.12.4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -110,7 +110,7 @@ jobs:
 
       - name: Upload smoke artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-artifacts
           path: |


### PR DESCRIPTION
## Summary
- upgrade CI workflow actions in `.github/workflows/ci.yml` to v6
- bump `actions/checkout`, `actions/setup-node`, and `actions/upload-artifact` usages
- keep workflow behavior otherwise unchanged to minimize rollout risk

## Validation
- local pre-push hooks completed (`pnpm build`, `pnpm -C web build`)
- PR CI will verify lint/typecheck/build, artifact upload path, and workflow compatibility

Closes #32

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version bumps to CI-only GitHub Actions; risk is limited to potential workflow compatibility/regressions in checkout/node setup/artifact upload.
> 
> **Overview**
> Upgrades the CI workflow to use `actions/checkout@v6`, `actions/setup-node@v6`, and `actions/upload-artifact@v6` across desktop, frontend, and smoke-test jobs, with no other workflow behavior changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f331efd8bf60a4d224c12acee028df02832ed099. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->