### PR TITLE
ci: upgrade core GitHub Actions to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -28,7 +28,7 @@ jobs:
           version: 10.12.4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -54,7 +54,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -62,7 +62,7 @@ jobs:
           version: 10.12.4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -89,7 +89,7 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -97,7 +97,7 @@ jobs:
           version: 10.12.4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -110,7 +110,7 @@ jobs:
 
       - name: Upload smoke artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-artifacts
           path: |


### PR DESCRIPTION
## Summary
- upgrade CI workflow actions in  to v6
- bump , , and  usages
- keep workflow behavior otherwise unchanged to minimize rollout risk

## Validation
- local pre-push hooks completed (
> agent-observer@1.1.0 build /Users/tradecraft/dev/agent-space
> electron-vite build

vite v6.4.1 building SSR bundle for production...
transforming...
✓ 14 modules transformed.
rendering chunks...
out/main/index.js  132.53 kB
✓ built in 180ms
vite v6.4.1 building SSR bundle for production...
transforming...
✓ 1 modules transformed.
rendering chunks...
out/preload/index.js  8.61 kB
✓ built in 10ms
vite v6.4.1 building for production...
transforming...
✓ 1888 modules transformed.
rendering chunks...
../../out/renderer/chat-window.html                             0.71 kB
../../out/renderer/index.html                                   0.77 kB
../../out/renderer/assets/codicon-ngg6Pgfi.ttf                121.97 kB
../../out/renderer/assets/json.worker-D4JVmXIe.js             840.01 kB
../../out/renderer/assets/html.worker-BT47iy49.js           1,241.54 kB
../../out/renderer/assets/css.worker-umuuUiIb.js            1,865.95 kB
../../out/renderer/assets/ts.worker-C7hW3aY-.js            13,264.91 kB
../../out/renderer/assets/index-BKlWQB97.css                    5.56 kB
../../out/renderer/assets/ChatPanel-C-IXCzdK.css               19.85 kB
../../out/renderer/assets/FileEditorPanel-B6UfNlAV.css        206.31 kB
../../out/renderer/assets/chat-window-ZTU7paFL.js               0.78 kB
../../out/renderer/assets/CollapsibleSection-D-OCGLcv.js        1.25 kB
../../out/renderer/assets/azcli-BEAhqcuE.js                     1.30 kB
../../out/renderer/assets/javascript-CE6xZRW2.js                1.38 kB
../../out/renderer/assets/costEngine-B6H1_Aj9.js                1.55 kB
../../out/renderer/assets/ini-BcQysCTb.js                       1.67 kB
../../out/renderer/assets/csp-D_3BK2Wp.js                       1.70 kB
../../out/renderer/assets/scheme-D7PxodDG.js                    2.36 kB
../../out/renderer/assets/RecentMemoriesPanel-CvSBj3IK.js       2.65 kB
../../out/renderer/assets/bat-Bqkp9Cfu.js                       2.66 kB
../../out/renderer/assets/flow9-ZSTChSMd.js                     2.76 kB
../../out/renderer/assets/sb-Chfc_wZF.js                        2.81 kB
../../out/renderer/assets/xml-BNE9PjN8.js                       2.82 kB
../../out/renderer/assets/pla-DEV89yYj.js                       2.87 kB
../../out/renderer/assets/dockerfile--oxj0cAH.js                3.02 kB
../../out/renderer/assets/AgentsPanel-TwXqPwtD.js               3.14 kB
../../out/renderer/assets/pascaligo-VA_LQ1oU.js                 3.25 kB
../../out/renderer/assets/lua-hNsuGJkO.js                       3.43 kB
../../out/renderer/assets/bicep-DIlfshcM.js                     3.44 kB
../../out/renderer/assets/objective-c-B1L1C5EC.js               3.48 kB
../../out/renderer/assets/cameligo-CLaaYNMV.js                  3.51 kB
../../out/renderer/assets/graphql-BeiGgjIU.js                   3.77 kB
../../out/renderer/assets/lexon-C1U0m2n9.js                     3.81 kB
../../out/renderer/assets/typespec-R77Ln7Jb.js                  3.90 kB
../../out/renderer/assets/sparql-DxuVdnRl.js                    3.94 kB
../../out/renderer/assets/mips-CJm71dS3.js                      4.14 kB
../../out/renderer/assets/m3-6ko6q9-_.js                        4.15 kB
../../out/renderer/assets/sophia-D7pU0Y1d.js                    4.27 kB
../../out/renderer/assets/shell-vZEubQ82.js                     4.48 kB
../../out/renderer/assets/go-brnMpFrj.js                        4.49 kB
../../out/renderer/assets/fsharp-D2uoxuLH.js                    4.51 kB
../../out/renderer/assets/pascal-DMQyD4Xk.js                    4.71 kB
../../out/renderer/assets/r-CtqYUQ6l.js                         4.80 kB
../../out/renderer/assets/less-B7Qaxw-O.js                      5.00 kB
../../out/renderer/assets/tcl-Bb4GCwBr.js                       5.05 kB
../../out/renderer/assets/qsharp-BWK6YLKm.js                    5.14 kB
../../out/renderer/assets/liquid-BxfcNQuE.js                    5.15 kB
../../out/renderer/assets/cypher-D0--_GAN.js                    5.15 kB
../../out/renderer/assets/java-Dt3iMn2o.js                      5.16 kB
../../out/renderer/assets/kotlin-Ddo1SjA5.js                    5.20 kB
../../out/renderer/assets/hcl-CrX1Es2W.js                       5.21 kB
../../out/renderer/assets/redis-O7gSt3oh.js                     5.25 kB
../../out/renderer/assets/restructuredtext-B-KQCVu_.js          5.33 kB
../../out/renderer/assets/powershell-BXiKvz7Z.js                5.39 kB
../../out/renderer/assets/coffee-CzJ5oEdj.js                    5.51 kB
../../out/renderer/assets/ActivityPanel-CObI2wn6.js             5.56 kB
../../out/renderer/assets/mdx-Dje7fkTp.js                       5.83 kB
../../out/renderer/assets/yaml-CgF0Fel1.js                      5.89 kB
../../out/renderer/assets/css-i3rI3_64.js                       6.10 kB
../../out/renderer/assets/cssMode-Dvi7itKZ.js                   6.22 kB
../../out/renderer/assets/rust-B1c0VCeq.js                      6.27 kB
../../out/renderer/assets/apex-DVGUZ64i.js                      6.39 kB
../../out/renderer/assets/dart-vLMHv35g.js                      6.48 kB
../../out/renderer/assets/python-BFgusgxZ.js                    6.51 kB
../../out/renderer/assets/HelpPanel-BnxY7uBu.js                 6.54 kB
../../out/renderer/assets/markdown-B0YTnTxW.js                  6.65 kB
../../out/renderer/assets/msdax-BBeIktCY.js                     6.95 kB
../../out/renderer/assets/htmlMode-Sa4OzKeB.js                  6.96 kB
../../out/renderer/assets/csharp-BJeIuvde.js                    6.98 kB
../../out/renderer/assets/swift-BmOZGynf.js                     7.18 kB
../../out/renderer/assets/html-CwXfik0t.js                      7.63 kB
../../out/renderer/assets/typescript-Bxe8RCsA.js                7.91 kB
../../out/renderer/assets/ecl-CeuUgzaZ.js                       7.94 kB
../../out/renderer/assets/FileSearchPanel-CpICmwyY.js           7.99 kB
../../out/renderer/assets/cpp-CcN6f0ik.js                       8.22 kB
../../out/renderer/assets/pug-BxCXwerb.js                       8.26 kB
../../out/renderer/assets/vb-Bm6ESA0Q.js                        8.33 kB
../../out/renderer/assets/scss-B42qMyAu.js                      9.07 kB
../../out/renderer/assets/wgsl-_KPae5vw.js                      9.78 kB
../../out/renderer/assets/st-C-b0Dh53.js                       10.15 kB
../../out/renderer/assets/twig-DvgEGWAV.js                     10.26 kB
../../out/renderer/assets/handlebars-BigD9u2I.js               10.41 kB
../../out/renderer/assets/julia-Cm3ItYL_.js                    10.54 kB
../../out/renderer/assets/scala-DbVzH-3O.js                    10.70 kB
../../out/renderer/assets/systemverilog-BOC0OOdC.js            11.63 kB
../../out/renderer/assets/php-Bkx1qpkQ.js                      12.48 kB
../../out/renderer/assets/protobuf-CndvAUGu.js                 12.68 kB
../../out/renderer/assets/perl-DC0Z0tlO.js                     12.82 kB
../../out/renderer/assets/razor-DdMHzZOG.js                    13.34 kB
../../out/renderer/assets/clojure-fcgFaMHx.js                  13.94 kB
../../out/renderer/assets/TokensPanel-vv9csQJL.js              14.75 kB
../../out/renderer/assets/ruby-DCd4DmAr.js                     15.31 kB
../../out/renderer/assets/sql-BAGepFCR.js                      15.56 kB
../../out/renderer/assets/mysql-BWiizXSn.js                    16.16 kB
../../out/renderer/assets/redshift-CvYMMYZY.js                 16.33 kB
../../out/renderer/assets/pgsql-DaSGFTLp.js                    18.25 kB
../../out/renderer/assets/elixir-eLfY1jWH.js                   18.74 kB
../../out/renderer/assets/postiats-CVVurEnu.js                 19.30 kB
../../out/renderer/assets/powerquery-BQ_t1ZiQ.js               21.65 kB
../../out/renderer/assets/abap-D5KwWAsZ.js                     22.97 kB
../../out/renderer/assets/solidity-yHOxYChb.js                 26.03 kB
../../out/renderer/assets/FileExplorerPanel-BwdyxBwT.js        27.72 kB
../../out/renderer/assets/jsonMode-SiF5F71Z.js                 29.19 kB
../../out/renderer/assets/tsMode-ChXZU7Vy.js                   40.39 kB
../../out/renderer/assets/freemarker2-B8DkA6Eo.js              42.17 kB
../../out/renderer/assets/lspLanguageFeatures-BtV2sNbL.js      61.70 kB
../../out/renderer/assets/SettingsPanel-CxidPfRw.js           101.15 kB
../../out/renderer/assets/index-s5MX35OQ.js                   544.09 kB
../../out/renderer/assets/ChatPanel-BegntSX4.js               714.31 kB
../../out/renderer/assets/ScenePanel-Dd9heRkw.js            2,019.50 kB
../../out/renderer/assets/FileEditorPanel-_Hmfgld7.js       7,343.85 kB
✓ built in 13.30s, 
> agent-observer-web@0.1.0 build /Users/tradecraft/dev/agent-space/web
> next build --webpack

▲ Next.js 16.1.6 (webpack)

[MDX] generated files in 7.326583000000028ms
  Creating an optimized production build ...
✓ Compiled successfully in 4.0s
  Running TypeScript ...
  Collecting page data using 15 workers ...
  Generating static pages using 15 workers (0/29) ...
  Generating static pages using 15 workers (7/29) 
  Generating static pages using 15 workers (14/29) 
  Generating static pages using 15 workers (21/29) 
✓ Generating static pages using 15 workers (29/29) in 433.5ms
  Finalizing page optimization ...
  Collecting build traces ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ƒ /api/docs/raw
├ ƒ /api/search
├ ○ /apple-icon.png
├ ● /docs/[[...slug]]
│ ├ /docs/architecture
│ ├ /docs
│ ├ /docs/integrations
│ └ [+16 more paths]
├ ○ /icon.png
├ ○ /robots.txt
└ ○ /sitemap.xml


○  (Static)   prerendered as static content
●  (SSG)      prerendered as static HTML (uses generateStaticParams)
ƒ  (Dynamic)  server-rendered on demand)
- PR CI will verify lint/typecheck/build, artifact upload path, and workflow compatibility

Closes #32

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since it only upgrades GitHub Actions versions; primary risk is CI behavior changes due to action version updates.
> 
> **Overview**
> Updates the `CI` GitHub Actions workflow to use `actions/checkout@v6`, `actions/setup-node@v6`, and `actions/upload-artifact@v6` across desktop, frontend, and smoke-test jobs.
> 
> No build/test commands or job structure change; this is a dependency bump for the workflow runners/actions only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f331efd8bf60a4d224c12acee028df02832ed099. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->