### PR TITLE
test: stabilize smoke assertion for folder control visibility

### DIFF
--- a/tests/smoke/desktop.smoke.spec.ts
+++ b/tests/smoke/desktop.smoke.spec.ts
@@ -28,7 +28,12 @@ test('desktop smoke flows: launch, reopen, folder scope, popout, terminal', asyn
     }
 
     await expect(mainWindow.locator('.slot-tab', { hasText: 'CHAT' }).first()).toBeVisible()
-    await expect(mainWindow.getByRole('button', { name: 'Choose folder' }).first()).toBeVisible()
+    const chooseFolderButton = mainWindow.getByRole('button', { name: 'Choose folder' }).first()
+    if (await chooseFolderButton.count()) {
+      await expect(chooseFolderButton).toBeVisible()
+    } else {
+      await expect(mainWindow.getByRole('button', { name: 'pick' }).first()).toBeVisible()
+    }
 
     // Regression check: unsolicited Claude events must be ignored when no
     // active Claude session is tracked in this chat panel.


### PR DESCRIPTION
## Summary
- make smoke test resilient to current startup workspace state
- assert `Choose folder` when empty-state chat is shown, otherwise assert header `pick` control

## Validation
- pnpm test:smoke

Closes #52

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that relaxes a UI assertion to handle multiple valid startup states; no production logic is modified.
> 
> **Overview**
> Updates the desktop smoke test to **conditionally assert** the folder-selection UI: it now expects `Choose folder` when the empty-state chat view is shown, otherwise it asserts the header `pick` button.
> 
> This stabilizes startup smoke coverage across runs where a workspace may already be set or onboarding state differs, reducing flaky failures without changing app behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c8d607e12e98a77471125222518d8a0c4c0c38e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->