### PR TITLE
fix: resolve paths in fs:stat IPC handler

### DIFF
--- a/src/main/filesystem.ts
+++ b/src/main/filesystem.ts
@@ -612,7 +612,8 @@ export function setupFilesystemHandlers(mainWindow?: BrowserWindow): void {
 
   ipcMain.handle('fs:stat', async (_event, filePath: string) => {
     try {
-      const stat = await fs.promises.stat(filePath)
+      const resolved = path.resolve(filePath)
+      const stat = await fs.promises.stat(resolved)
       return {
         isDirectory: stat.isDirectory(),
         isFile: stat.isFile(),


### PR DESCRIPTION
## Summary
- resolve `filePath` before calling `fs.promises.stat` in `fs:stat`
- aligns stat behavior with other filesystem IPC handlers that already normalize paths

## Validation
- pnpm run lint:desktop
- pnpm run typecheck
- pnpm test:smoke

Closes #53

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, localized change that normalizes the input path before `stat`, aligning with other handlers and unlikely to affect data beyond path resolution edge cases.
> 
> **Overview**
> Normalizes `fs:stat` IPC behavior by resolving the incoming `filePath` with `path.resolve()` before calling `fs.promises.stat`.
> 
> This aligns `fs:stat` with other filesystem IPC handlers that already operate on normalized absolute paths, reducing inconsistencies when callers pass relative paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b62b8873830524212ffceb60b3f492e009457b8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->