### PR TITLE
fix: write settings, scheduler, and todo state atomically

### DIFF
--- a/src/main/atomic-write.ts
+++ b/src/main/atomic-write.ts
@@ -1,0 +1,50 @@
+import fs from 'fs'
+import path from 'path'
+
+/**
+ * Atomically replace file contents using write + fsync + rename.
+ * Best-effort fsync on parent directory is included for durability.
+ */
+export function writeFileAtomicSync(targetPath: string, content: string): void {
+  const dir = path.dirname(targetPath)
+  const baseName = path.basename(targetPath)
+  const tempPath = path.join(dir, `.${baseName}.${process.pid}.${Date.now()}.tmp`)
+  let fd: number | null = null
+
+  try {
+    fd = fs.openSync(tempPath, 'w')
+    fs.writeFileSync(fd, content, 'utf-8')
+    fs.fsyncSync(fd)
+    fs.closeSync(fd)
+    fd = null
+
+    fs.renameSync(tempPath, targetPath)
+
+    try {
+      const dirFd = fs.openSync(dir, 'r')
+      try {
+        fs.fsyncSync(dirFd)
+      } finally {
+        fs.closeSync(dirFd)
+      }
+    } catch {
+      // Best effort; directory fsync may fail on some platforms.
+    }
+  } catch (err) {
+    if (fd !== null) {
+      try {
+        fs.closeSync(fd)
+      } catch {
+        // Ignore close errors during cleanup.
+      }
+    }
+    try {
+      if (fs.existsSync(tempPath)) {
+        fs.unlinkSync(tempPath)
+      }
+    } catch {
+      // Ignore temp cleanup failures.
+    }
+    throw err
+  }
+}

--- a/src/main/scheduler.ts
+++ b/src/main/scheduler.ts
@@ -7,6 +7,7 @@ import path from 'path'
 import { getClaudeBinaryPath, getClaudeEnvironment } from './claude-session'
 import { logMainError, logMainEvent } from './diagnostics'
 import { resolveClaudeProfileForDirectory } from './claude-profile'
+import { writeFileAtomicSync } from './atomic-write'
 
 type SchedulerRunStatus = 'idle' | 'running' | 'success' | 'error'
 type SchedulerRunTrigger = 'cron' | 'manual'
@@ -340,7 +341,7 @@ function readTasksFromDisk(): SchedulerTask[] {
 
 function writeTasksToDisk(tasks: SchedulerTask[]): void {
   ensureSchedulerDir()
-  fs.writeFileSync(SCHEDULER_FILE, JSON.stringify(tasks, null, 2), 'utf-8')
+  writeFileAtomicSync(SCHEDULER_FILE, JSON.stringify(tasks, null, 2))
 }
 
 function loadTasksCache(): void {

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -3,6 +3,7 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import type { AppSettings } from '../renderer/types'
+import { writeFileAtomicSync } from './atomic-write'
 
 const DEFAULT_LOCAL_DEV_DIRECTORY = path.join(os.homedir(), 'dev')
 
@@ -122,7 +123,7 @@ export function loadSettings(): AppSettings {
       const normalized = normalizeStartingDirectory(merged)
       cachedSettings = normalized.settings
       if (normalized.changed) {
-        fs.writeFileSync(SETTINGS_FILE, JSON.stringify(cachedSettings, null, 2), 'utf-8')
+        writeFileAtomicSync(SETTINGS_FILE, JSON.stringify(cachedSettings, null, 2))
       }
     } else {
       cachedSettings = { ...DEFAULT_SETTINGS }
@@ -138,7 +139,7 @@ function saveSettings(settings: AppSettings): void {
     if (!fs.existsSync(SETTINGS_DIR)) {
       fs.mkdirSync(SETTINGS_DIR, { recursive: true })
     }
-    fs.writeFileSync(SETTINGS_FILE, JSON.stringify(settings, null, 2), 'utf-8')
+    writeFileAtomicSync(SETTINGS_FILE, JSON.stringify(settings, null, 2))
     cachedSettings = settings
   } catch (err) {
     console.error('Failed to save settings:', err)

--- a/src/main/todo-runner.ts
+++ b/src/main/todo-runner.ts
@@ -5,6 +5,7 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import { logMainError, logMainEvent } from './diagnostics'
+import { writeFileAtomicSync } from './atomic-write'
 
 type TodoRunnerRunStatus = 'idle' | 'running' | 'success' | 'error'
 type TodoRunnerRunTrigger = 'auto' | 'manual'
@@ -257,7 +258,7 @@ function readJobsFromDisk(): TodoRunnerJobRecord[] {
 
 function writeJobsToDisk(jobs: TodoRunnerJobRecord[]): void {
   ensureTodoRunnerDir()
-  fs.writeFileSync(TODO_RUNNER_FILE, JSON.stringify(jobs, null, 2), 'utf-8')
+  writeFileAtomicSync(TODO_RUNNER_FILE, JSON.stringify(jobs, null, 2))
 }
 
 function loadJobsCache(): void {


### PR DESCRIPTION
## Summary
- add shared atomic write helper (`write + fsync + rename`)
- switch settings persistence to atomic writes
- switch scheduler and todo-runner JSON persistence to atomic writes

## Validation
- pnpm run lint:desktop
- pnpm run typecheck
- pnpm test:smoke

Closes #59

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches on-disk persistence paths used by core app state; while the change is localized, filesystem semantics and `fsync` behavior can vary across platforms and could impact reliability if incorrect.
> 
> **Overview**
> Adds a shared `writeFileAtomicSync` helper that persists files via temp-file write + `fsync` + `rename`, with best-effort directory `fsync` and cleanup on failure.
> 
> Switches JSON persistence for `settings.json`, `schedules.json`, and `todo-runner.json` from direct `fs.writeFileSync` to atomic writes to avoid partial/corrupted state files during crashes or interruptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46638677f89a8b588dd2b211db3ed158778664c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->