### PR TITLE
feat: serve desktop installer from website download route

### DIFF
--- a/web/content/docs/index.mdx
+++ b/web/content/docs/index.mdx
@@ -43,6 +43,6 @@ Agent Observer documentation is organized around real operator workflows:
 
 ## Install
 
-1. Download the latest macOS build from [GitHub Releases](https://github.com/webrenew/agent-space/releases/latest).
+1. Download the latest macOS build from the [website installer](/download).
 2. Open the `.dmg` and drag **Agent Observer** to `Applications`.
 3. Launch and complete first-run workspace setup.

--- a/web/content/docs/quickstart.mdx
+++ b/web/content/docs/quickstart.mdx
@@ -15,7 +15,7 @@ This quickstart gets a new install from zero to a validated workflow in about 10
 
 ## Install Agent Observer
 
-1. Download the latest release from [GitHub Releases](https://github.com/webrenew/agent-space/releases/latest).
+1. Download the latest release from the [website installer](/download).
 2. Open the `.dmg`.
 3. Drag **Agent Observer** into `Applications`.
 4. Launch from `Applications`.

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -5,6 +5,7 @@
 ## Canonical sources
 
 - Website: /
+- Installer: /download
 - Repository: https://github.com/webrenew/agent-space
 - Releases: https://github.com/webrenew/agent-space/releases/latest
 
@@ -25,6 +26,7 @@
 - /docs/reference/permissions : macOS permission behavior
 - /docs/reference/troubleshooting : Common issue resolution
 - /docs/reference/status-model : UI status and label semantics
+- /download : Redirects to latest desktop installer binary
 - /#download : Desktop download and install steps
 
 ## Core capabilities
@@ -37,7 +39,7 @@
 
 ## Install
 
-1. Download the latest `.dmg` from releases.
+1. Download the latest `.dmg` from `/download`.
 2. Open the DMG and drag Agent Observer into `Applications`.
 3. Launch from `Applications` and approve requested permissions.
 
@@ -60,7 +62,7 @@
 
 ## Notes for language models
 
-- Prefer official release binaries from the Releases URL above.
+- Prefer official installer binaries from `/download`.
 - Prefer repository references from the GitHub source URL above.
 - Prefer `/docs/*` pages for feature behavior and product usage details.
 - If unsure about install steps, direct users to `/#download` first.

--- a/web/src/app/download/route.ts
+++ b/web/src/app/download/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import {
+  AGENT_SPACE_RELEASES_API_URL,
+  AGENT_SPACE_RELEASES_URL,
+  resolveLatestInstallerAssetUrl,
+  type GitHubLatestRelease,
+} from "@/lib/downloads";
+
+const CACHE_CONTROL = "public, s-maxage=300, stale-while-revalidate=3600";
+const GITHUB_ACCEPT = "application/vnd.github+json";
+const GITHUB_API_VERSION = "2022-11-28";
+const GITHUB_USER_AGENT = "agent-observer-web-download";
+
+async function resolveInstallerUrl(): Promise<string> {
+  try {
+    const response = await fetch(AGENT_SPACE_RELEASES_API_URL, {
+      headers: {
+        Accept: GITHUB_ACCEPT,
+        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+        "User-Agent": GITHUB_USER_AGENT,
+      },
+      next: { revalidate: 300 },
+    });
+
+    if (!response.ok) return AGENT_SPACE_RELEASES_URL;
+
+    const release = (await response.json()) as GitHubLatestRelease;
+    const assets = Array.isArray(release.assets) ? release.assets : [];
+    return resolveLatestInstallerAssetUrl(assets) ?? AGENT_SPACE_RELEASES_URL;
+  } catch {
+    return AGENT_SPACE_RELEASES_URL;
+  }
+}
+
+export async function GET(): Promise<Response> {
+  const installerUrl = await resolveInstallerUrl();
+  const response = NextResponse.redirect(installerUrl, { status: 302 });
+  response.headers.set("Cache-Control", CACHE_CONTROL);
+  return response;
+}

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -17,6 +17,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "weekly",
       priority: 1,
     },
+    {
+      url: `${SITE_URL}/download`,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 0.85,
+    },
     ...docsPages,
   ];
 }

--- a/web/src/components/seo/ContentSection.tsx
+++ b/web/src/components/seo/ContentSection.tsx
@@ -1,4 +1,4 @@
-import { AGENT_SPACE_RELEASES_URL } from "@/lib/downloads";
+import { AGENT_SPACE_INSTALLER_URL } from "@/lib/downloads";
 import Link from "next/link";
 
 const FEATURES = [
@@ -277,15 +277,13 @@ export function ContentSection() {
               maxWidth: 880,
             }}
           >
-            Get the latest desktop release from GitHub, open the DMG, and drag
-            Agent Observer into your Applications folder.
+            Download the latest installer directly from this site, open the DMG,
+            and drag Agent Observer into your Applications folder.
           </p>
 
           <div className="flex flex-wrap items-center gap-8">
             <a
-              href={AGENT_SPACE_RELEASES_URL}
-              target="_blank"
-              rel="noreferrer"
+              href={AGENT_SPACE_INSTALLER_URL}
               style={{
                 display: "inline-flex",
                 alignItems: "center",
@@ -320,7 +318,7 @@ export function ContentSection() {
               lineHeight: 1.6,
             }}
           >
-            <li>Open the latest release page and download the `.dmg` installer.</li>
+            <li>Use the website installer link to download the latest `.dmg`.</li>
             <li>Open the DMG, then drag Agent Observer into `Applications`.</li>
             <li>Launch Agent Observer from Applications and approve requested permissions.</li>
           </ol>

--- a/web/src/components/ui/FallbackPage.tsx
+++ b/web/src/components/ui/FallbackPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AGENT_SPACE_RELEASES_URL } from "@/lib/downloads";
+import { AGENT_SPACE_INSTALLER_URL } from "@/lib/downloads";
 
 const FEATURES = [
   {
@@ -107,9 +107,7 @@ export function FallbackPage() {
 
         <div className="mt-8 flex flex-wrap items-center gap-10">
           <a
-            href={AGENT_SPACE_RELEASES_URL}
-            target="_blank"
-            rel="noreferrer"
+            href={AGENT_SPACE_INSTALLER_URL}
             style={{
               display: "inline-flex",
               alignItems: "center",

--- a/web/src/components/ui/HUD.tsx
+++ b/web/src/components/ui/HUD.tsx
@@ -6,7 +6,7 @@ import { useDemoStore } from "@/stores/useDemoStore";
 import { STATUS_LABELS, AGENT_COLORS } from "@/types";
 import type { AgentStatus } from "@/types";
 import type { CelebrationType } from "@/types";
-import { AGENT_SPACE_RELEASES_URL } from "@/lib/downloads";
+import { AGENT_SPACE_INSTALLER_URL } from "@/lib/downloads";
 import { setManualAgentOverride } from "@/lib/simulation";
 import { Minimap } from "./Minimap";
 
@@ -1290,9 +1290,7 @@ export function HUD() {
             docs
           </Link>
           <a
-            href={AGENT_SPACE_RELEASES_URL}
-            target="_blank"
-            rel="noreferrer"
+            href={AGENT_SPACE_INSTALLER_URL}
             style={{ color: "#d4a040", fontWeight: 600 }}
           >
             install

--- a/web/src/lib/downloads.ts
+++ b/web/src/lib/downloads.ts
@@ -2,3 +2,42 @@ import { SITE_REPO_URL, SITE_RELEASES_URL } from "@/lib/site";
 
 export const AGENT_SPACE_REPO_URL = SITE_REPO_URL;
 export const AGENT_SPACE_RELEASES_URL = SITE_RELEASES_URL;
+export const AGENT_SPACE_INSTALLER_URL = "/download";
+export const AGENT_SPACE_RELEASES_API_URL =
+  "https://api.github.com/repos/webrenew/agent-space/releases/latest";
+
+export interface GitHubReleaseAsset {
+  name: string;
+  browser_download_url: string;
+  content_type?: string | null;
+}
+
+export interface GitHubLatestRelease {
+  assets?: GitHubReleaseAsset[] | null;
+}
+
+const APPLE_DISK_IMAGE_CONTENT_TYPE = "application/x-apple-diskimage";
+const ARM64_NAME_MARKERS = ["arm64", "aarch64", "apple-silicon", "apple_silicon"];
+
+function isMacInstallerAsset(asset: GitHubReleaseAsset): boolean {
+  const contentType = asset.content_type?.toLowerCase();
+  return (
+    asset.name.toLowerCase().endsWith(".dmg") ||
+    contentType === APPLE_DISK_IMAGE_CONTENT_TYPE
+  );
+}
+
+function hasArm64Marker(assetName: string): boolean {
+  const normalized = assetName.toLowerCase();
+  return ARM64_NAME_MARKERS.some((marker) => normalized.includes(marker));
+}
+
+export function resolveLatestInstallerAssetUrl(
+  assets: GitHubReleaseAsset[]
+): string | null {
+  const macInstallerAssets = assets.filter(isMacInstallerAsset);
+  if (macInstallerAssets.length === 0) return null;
+
+  const preferred = macInstallerAssets.find((asset) => hasArm64Marker(asset.name));
+  return (preferred ?? macInstallerAssets[0]).browser_download_url;
+}


### PR DESCRIPTION
## Summary
- add a first-party /download route that resolves the latest release asset and redirects to the installer binary
- switch website install CTAs/docs from GitHub Releases links to /download
- update install guidance content and sitemap/llms metadata for the new installer flow

## Validation
- pnpm -C web run lint
- pnpm -C web run build
- pnpm run lint
- pnpm run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new cached server route that fetches GitHub release metadata and redirects users to a selected installer asset; failures or API/rate-limit changes could break downloads despite a fallback to the Releases page.
> 
> **Overview**
> Introduces a first-party `GET /download` route that queries the GitHub latest release API, selects a macOS `.dmg` asset (preferring arm64 markers), and returns a cached `302` redirect with a Releases-page fallback.
> 
> Updates install CTAs and documentation to point to `/download` instead of GitHub Releases (including `llms.txt` guidance) and adds `/download` to the sitemap for discovery.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afe11e6370028e98c96afd1bc6a4b32b0fc11bff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->