### PR TITLE
ci: run Electron smoke tests on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,12 +79,46 @@ jobs:
       - name: Frontend build
         run: pnpm -C web run build
 
+  smoke-scope:
+    name: Smoke Scope
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Decide smoke scope
+        id: decide
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+        run: |
+          if [ "$EVENT_NAME" = "push" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+          echo "Changed files:"
+          echo "$changed_files"
+
+          if echo "$changed_files" | grep -Eq '^(src/|tests/|playwright\.smoke\.config\.ts|electron\.vite\.config\.ts|package\.json|pnpm-lock\.yaml|\.github/workflows/ci\.yml)'; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   smoke-desktop:
     name: Desktop Smoke (Electron)
-    if: github.event_name == 'push'
+    if: needs.smoke-scope.outputs.should_run == 'true'
     needs:
       - desktop-checks
       - frontend-checks
+      - smoke-scope
     runs-on: macos-latest
     timeout-minutes: 25
     steps:


### PR DESCRIPTION
## Summary
- add a lightweight smoke-scope job that decides when smoke should run
- run desktop smoke for all pushes and for pull requests that touch desktop/smoke-critical paths
- keep macOS smoke cost controlled by skipping PRs that only change unrelated files

Closes #61

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that gates when a macOS smoke job runs; main risk is accidentally skipping smoke coverage due to incorrect path matching or diff SHAs.
> 
> **Overview**
> Adds a new `smoke-scope` job to decide whether Electron smoke tests should run by diffing PR base/head commits and checking for changes in smoke-critical paths.
> 
> Updates `smoke-desktop` to run on PRs when `smoke-scope` says to (and still always on `push`), gating the macOS workflow cost while preserving coverage for relevant changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35411a60f2cd7937a459bd7933dad7f3d7181e70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->