### PR TITLE
fix: cap stderr buffer growth for long-running chat sessions

### DIFF
--- a/src/main/claude-session.ts
+++ b/src/main/claude-session.ts
@@ -42,6 +42,7 @@ let sessionCounter = 0
 
 const CLAUDE_SESSION_DEFAULT_MAX_RUNTIME_MS = 30 * 60 * 1000
 const CLAUDE_SESSION_FORCE_KILL_TIMEOUT_MS = 5_000
+const CLAUDE_SESSION_STDERR_MAX_CHARS = 4_000
 
 function resolveSessionMaxRuntimeMs(): number {
   const raw = process.env.AGENT_SPACE_CLAUDE_MAX_RUNTIME_MS
@@ -503,6 +504,9 @@ function startSession(options: ClaudeSessionOptions): string {
   let stderrBuffer = ''
   proc.stderr?.on('data', (chunk: Buffer) => {
     stderrBuffer += chunk.toString()
+    if (stderrBuffer.length > CLAUDE_SESSION_STDERR_MAX_CHARS) {
+      stderrBuffer = stderrBuffer.slice(-CLAUDE_SESSION_STDERR_MAX_CHARS)
+    }
   })
 
   proc.on('error', (err: Error) => {


### PR DESCRIPTION
## Summary
- cap stderr buffering in `claude-session` to a bounded tail
- prevent unbounded memory growth from verbose long-running child stderr streams

Closes #75

## Validation
- pnpm run lint:desktop
- pnpm run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change that only affects stderr buffering and the amount of error context captured on failure.
> 
> **Overview**
> Caps Claude CLI stderr buffering in `claude-session` by keeping only the last `4_000` characters, preventing unbounded memory growth during long-running or very verbose sessions.
> 
> This changes error-reporting behavior to include only the bounded tail of stderr when a session exits non-zero.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eee5fd9a3491bbe2c2bae3e26bf3b3563927d885. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->