### PR TITLE
fix: prevent scheduler runtime leak after delete-while-running

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -261,6 +261,9 @@ const electronAPI: ElectronAPI = {
     runNow: (taskId: string) =>
       ipcRenderer.invoke('scheduler:runNow', taskId),
 
+    debugRuntimeSize: () =>
+      ipcRenderer.invoke('scheduler:debugRuntimeSize') as Promise<number>,
+
     onUpdated: (callback: () => void) => {
       const handler = () => callback()
       ipcRenderer.on('scheduler:updated', handler)

--- a/src/shared/electron-api.ts
+++ b/src/shared/electron-api.ts
@@ -159,6 +159,7 @@ export interface ElectronAPI {
     upsert: (task: SchedulerTaskInput) => Promise<SchedulerTask>
     delete: (taskId: string) => Promise<void>
     runNow: (taskId: string) => Promise<SchedulerTask>
+    debugRuntimeSize: () => Promise<number>
     onUpdated: (callback: () => void) => Unsubscribe
   }
   todoRunner: {


### PR DESCRIPTION
## Summary
- avoid recreating runtime entries when a task is deleted mid-run
- avoid returning stale runtime from `runNow` if the task was deleted during execution
- add smoke regression coverage for delete-while-running and runtime map stability

## Validation
- pnpm run lint:desktop
- pnpm run typecheck
- pnpm exec playwright test tests/smoke/desktop.smoke.spec.ts -c playwright.smoke.config.ts --workers=1

Closes #78

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches task execution completion paths and IPC surface area; failures could cause incorrect scheduler status reporting or regress delete/run behavior, but changes are localized and covered by a smoke regression test.
> 
> **Overview**
> Prevents scheduler runtime state from being recreated/updated when a task is deleted mid-run by checking task existence before writing final `runtimeByTaskId` entries on process `exit`/`error`, and explicitly clearing runtime for deleted tasks.
> 
> Updates `runNow` (`runTaskById`) to re-fetch the task after execution and throw `Task deleted during run` if it was removed, avoiding returning stale runtime. Adds a `scheduler:debugRuntimeSize` IPC endpoint (wired through preload and `ElectronAPI`) and extends the desktop smoke test to cover delete-while-running and assert the runtime map size remains stable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cbb957435560dde96f45e34e52bf71e7c352afb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->