### PR TITLE
Refactor SettingsPanel into modular tabs and hooks

### DIFF
--- a/src/renderer/components/settings/SchedulerTab.tsx
+++ b/src/renderer/components/settings/SchedulerTab.tsx
@@ -1,0 +1,317 @@
+import { Row, Section, Toggle } from './common'
+import { formatDateTime, formatDuration } from './utils'
+import type { SchedulerTaskDraft } from './types'
+
+const DEFAULT_CRON_EXAMPLES = ['*/15 * * * *', '0 * * * *', '0 9 * * 1-5', '30 18 * * *']
+
+interface SchedulerTabProps {
+  schedulerError: string | null
+  schedulerLoading: boolean
+  schedulerBusyId: string | null
+  scheduleDrafts: SchedulerTaskDraft[]
+  updateScheduleDraft: (taskId: string, updates: Partial<SchedulerTaskDraft>) => void
+  browseScheduleDirectory: (taskId: string) => Promise<void>
+  runScheduleNow: (task: SchedulerTaskDraft) => Promise<void>
+  saveSchedule: (task: SchedulerTaskDraft) => Promise<void>
+  removeSchedule: (task: SchedulerTaskDraft) => Promise<void>
+  addScheduleDraft: () => void
+}
+
+export function SchedulerTab({
+  schedulerError,
+  schedulerLoading,
+  schedulerBusyId,
+  scheduleDrafts,
+  updateScheduleDraft,
+  browseScheduleDirectory,
+  runScheduleNow,
+  saveSchedule,
+  removeSchedule,
+  addScheduleDraft,
+}: SchedulerTabProps) {
+  return (
+    <Section title="CRON TASKS">
+      <div style={{ fontSize: 12, color: '#74747C', marginBottom: 8, lineHeight: 1.5 }}>
+        Run Claude prompts on a cron schedule in a selected directory.
+        Use five cron fields: minute hour day month weekday.
+      </div>
+      <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 10 }}>
+        {DEFAULT_CRON_EXAMPLES.map((example) => (
+          <span
+            key={example}
+            style={{
+              fontSize: 11,
+              color: '#595653',
+              border: '1px solid rgba(89,86,83,0.25)',
+              borderRadius: 999,
+              padding: '2px 8px',
+            }}
+          >
+            {example}
+          </span>
+        ))}
+      </div>
+
+      {schedulerError && (
+        <div
+          style={{
+            marginBottom: 10,
+            padding: '8px 10px',
+            borderRadius: 6,
+            border: '1px solid rgba(196,80,80,0.4)',
+            background: 'rgba(196,80,80,0.1)',
+            color: '#c45050',
+            fontSize: 12,
+          }}
+        >
+          {schedulerError}
+        </div>
+      )}
+
+      {schedulerLoading && (
+        <div style={{ fontSize: 12, color: '#595653', marginBottom: 10 }}>
+          Loading schedules...
+        </div>
+      )}
+
+      {scheduleDrafts.length === 0 && !schedulerLoading && (
+        <div style={{ fontSize: 12, color: '#595653', marginBottom: 10 }}>
+          No schedules yet.
+        </div>
+      )}
+
+      {scheduleDrafts.map((task) => {
+        const busy = schedulerBusyId === task.id
+        const statusColor =
+          task.lastStatus === 'success'
+            ? '#548C5A'
+            : task.lastStatus === 'error'
+              ? '#c45050'
+              : task.lastStatus === 'running'
+                ? '#d4a040'
+                : '#74747C'
+
+        return (
+          <div
+            key={task.id}
+            style={{
+              border: '1px solid rgba(89,86,83,0.25)',
+              borderRadius: 8,
+              padding: 10,
+              marginBottom: 10,
+              background: 'rgba(14,14,13,0.35)',
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+              <input
+                type="text"
+                value={task.name}
+                onChange={(e) => updateScheduleDraft(task.id, { name: e.target.value })}
+                placeholder="Task name"
+                style={{
+                  flex: 1,
+                  background: 'rgba(89,86,83,0.15)',
+                  border: '1px solid rgba(89,86,83,0.3)',
+                  borderRadius: 6,
+                  padding: '5px 8px',
+                  fontSize: 13,
+                  color: '#9A9692',
+                  outline: 'none',
+                  fontFamily: 'inherit',
+                }}
+              />
+              <Toggle
+                checked={task.enabled}
+                onChange={(enabled) => updateScheduleDraft(task.id, { enabled })}
+              />
+            </div>
+
+            <Row label="Cron">
+              <input
+                type="text"
+                value={task.cron}
+                onChange={(e) => updateScheduleDraft(task.id, { cron: e.target.value })}
+                placeholder="0 9 * * 1-5"
+                style={{
+                  width: 170,
+                  background: 'rgba(89,86,83,0.15)',
+                  border: '1px solid rgba(89,86,83,0.3)',
+                  borderRadius: 6,
+                  padding: '5px 8px',
+                  fontSize: 13,
+                  color: '#9A9692',
+                  outline: 'none',
+                  fontFamily: 'inherit',
+                }}
+              />
+            </Row>
+
+            <Row label="Directory">
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <input
+                  type="text"
+                  value={task.workingDirectory}
+                  onChange={(e) => updateScheduleDraft(task.id, { workingDirectory: e.target.value })}
+                  placeholder="/path/to/project"
+                  style={{
+                    width: 220,
+                    background: 'rgba(89,86,83,0.15)',
+                    border: '1px solid rgba(89,86,83,0.3)',
+                    borderRadius: 6,
+                    padding: '5px 8px',
+                    fontSize: 13,
+                    color: '#9A9692',
+                    outline: 'none',
+                    fontFamily: 'inherit',
+                  }}
+                />
+                <button
+                  onClick={() => void browseScheduleDirectory(task.id)}
+                  style={{
+                    padding: '5px 10px',
+                    fontSize: 12,
+                    fontWeight: 500,
+                    background: 'rgba(89,86,83,0.15)',
+                    border: '1px solid rgba(89,86,83,0.3)',
+                    borderRadius: 6,
+                    color: '#9A9692',
+                    cursor: 'pointer',
+                    fontFamily: 'inherit',
+                  }}
+                >
+                  Browse...
+                </button>
+              </div>
+            </Row>
+
+            <Row label="YOLO mode">
+              <Toggle
+                checked={task.yoloMode}
+                onChange={(yoloMode) => updateScheduleDraft(task.id, { yoloMode })}
+              />
+            </Row>
+
+            <div style={{ marginTop: 8 }}>
+              <div style={{ fontSize: 10, color: '#74747C', marginBottom: 4, letterSpacing: 0.8 }}>
+                PROMPT
+              </div>
+              <textarea
+                value={task.prompt}
+                onChange={(e) => updateScheduleDraft(task.id, { prompt: e.target.value })}
+                placeholder="What should Claude do on each run?"
+                rows={4}
+                style={{
+                  width: '100%',
+                  background: 'rgba(89,86,83,0.15)',
+                  border: '1px solid rgba(89,86,83,0.3)',
+                  borderRadius: 6,
+                  padding: '7px 8px',
+                  fontSize: 12,
+                  color: '#9A9692',
+                  outline: 'none',
+                  fontFamily: 'inherit',
+                  resize: 'vertical',
+                  lineHeight: 1.45,
+                }}
+              />
+            </div>
+
+            <div style={{ marginTop: 8, fontSize: 11, color: '#74747C', lineHeight: 1.5 }}>
+              <div>
+                Status:{' '}
+                <span style={{ color: statusColor, fontWeight: 600 }}>
+                  {task.isRunning ? 'running' : task.lastStatus}
+                </span>
+              </div>
+              <div>Next run: {formatDateTime(task.nextRunAt)}</div>
+              <div>
+                Last run: {formatDateTime(task.lastRunAt)}
+                {task.lastDurationMs != null ? ` (${formatDuration(task.lastDurationMs)})` : ''}
+              </div>
+              {task.lastError && (
+                <div style={{ color: '#c45050' }}>Last error: {task.lastError}</div>
+              )}
+            </div>
+
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 10 }}>
+              {!task.isDraft && (
+                <button
+                  onClick={() => void runScheduleNow(task)}
+                  disabled={busy}
+                  style={{
+                    padding: '5px 10px',
+                    fontSize: 12,
+                    fontWeight: 500,
+                    background: 'rgba(84,140,90,0.14)',
+                    border: '1px solid rgba(84,140,90,0.35)',
+                    borderRadius: 6,
+                    color: '#7fb887',
+                    cursor: busy ? 'default' : 'pointer',
+                    fontFamily: 'inherit',
+                    opacity: busy ? 0.5 : 1,
+                  }}
+                >
+                  Run now
+                </button>
+              )}
+              <button
+                onClick={() => void saveSchedule(task)}
+                disabled={busy}
+                style={{
+                  padding: '5px 10px',
+                  fontSize: 12,
+                  fontWeight: 500,
+                  background: 'rgba(89,86,83,0.15)',
+                  border: '1px solid rgba(89,86,83,0.3)',
+                  borderRadius: 6,
+                  color: '#9A9692',
+                  cursor: busy ? 'default' : 'pointer',
+                  fontFamily: 'inherit',
+                  opacity: busy ? 0.5 : 1,
+                }}
+              >
+                Save task
+              </button>
+              <button
+                onClick={() => void removeSchedule(task)}
+                disabled={busy}
+                style={{
+                  padding: '5px 10px',
+                  fontSize: 12,
+                  fontWeight: 500,
+                  background: 'rgba(196,80,80,0.12)',
+                  border: '1px solid rgba(196,80,80,0.32)',
+                  borderRadius: 6,
+                  color: '#c45050',
+                  cursor: busy ? 'default' : 'pointer',
+                  fontFamily: 'inherit',
+                  opacity: busy ? 0.5 : 1,
+                }}
+              >
+                {task.isDraft ? 'Discard' : 'Delete'}
+              </button>
+            </div>
+          </div>
+        )
+      })}
+
+      <button
+        onClick={addScheduleDraft}
+        style={{
+          marginTop: 4,
+          padding: '5px 12px',
+          fontSize: 12,
+          fontWeight: 500,
+          background: 'rgba(89,86,83,0.15)',
+          border: '1px solid rgba(89,86,83,0.3)',
+          borderRadius: 6,
+          color: '#9A9692',
+          cursor: 'pointer',
+          fontFamily: 'inherit',
+        }}
+      >
+        + Add Schedule
+      </button>
+    </Section>
+  )
+}

--- a/src/renderer/components/settings/TodoRunnerTab.tsx
+++ b/src/renderer/components/settings/TodoRunnerTab.tsx
@@ -1,0 +1,379 @@
+import { Row, Section, Toggle } from './common'
+import { formatDateTime, formatDuration } from './utils'
+import type { TodoRunnerJobDraft } from './types'
+
+interface TodoRunnerTabProps {
+  todoRunnerError: string | null
+  todoRunnerLoading: boolean
+  todoRunnerBusyId: string | null
+  todoRunnerDrafts: TodoRunnerJobDraft[]
+  updateTodoRunnerDraft: (jobId: string, updates: Partial<TodoRunnerJobDraft>) => void
+  browseTodoRunnerDirectory: (jobId: string) => Promise<void>
+  startTodoRunnerJob: (job: TodoRunnerJobDraft) => Promise<void>
+  pauseTodoRunnerJob: (job: TodoRunnerJobDraft) => Promise<void>
+  resetTodoRunnerJob: (job: TodoRunnerJobDraft) => Promise<void>
+  saveTodoRunnerJob: (job: TodoRunnerJobDraft) => Promise<void>
+  removeTodoRunnerJob: (job: TodoRunnerJobDraft) => Promise<void>
+  addTodoRunnerDraft: () => void
+}
+
+export function TodoRunnerTab({
+  todoRunnerError,
+  todoRunnerLoading,
+  todoRunnerBusyId,
+  todoRunnerDrafts,
+  updateTodoRunnerDraft,
+  browseTodoRunnerDirectory,
+  startTodoRunnerJob,
+  pauseTodoRunnerJob,
+  resetTodoRunnerJob,
+  saveTodoRunnerJob,
+  removeTodoRunnerJob,
+  addTodoRunnerDraft,
+}: TodoRunnerTabProps) {
+  return (
+    <Section title="TODO RUNNER">
+      <div style={{ fontSize: 12, color: '#74747C', marginBottom: 8, lineHeight: 1.5 }}>
+        Run a large todo list sequentially until complete using an external runner command.
+        This is designed for Agent SDK workers (without Claude Code CLI coupling).
+      </div>
+      <div style={{ fontSize: 11, color: '#595653', marginBottom: 10, lineHeight: 1.5 }}>
+        Runner contract: receives JSON payload on <code>stdin</code> and env vars
+        {' '}<code>AGENT_SPACE_TODO_PAYLOAD</code>, <code>AGENT_SPACE_TODO_TEXT</code>,
+        {' '}<code>AGENT_SPACE_TODO_INDEX</code>, <code>AGENT_SPACE_TODO_TOTAL</code>.
+      </div>
+
+      {todoRunnerError && (
+        <div
+          style={{
+            marginBottom: 10,
+            padding: '8px 10px',
+            borderRadius: 6,
+            border: '1px solid rgba(196,80,80,0.4)',
+            background: 'rgba(196,80,80,0.1)',
+            color: '#c45050',
+            fontSize: 12,
+          }}
+        >
+          {todoRunnerError}
+        </div>
+      )}
+
+      {todoRunnerLoading && (
+        <div style={{ fontSize: 12, color: '#595653', marginBottom: 10 }}>
+          Loading todo runs...
+        </div>
+      )}
+
+      {todoRunnerDrafts.length === 0 && !todoRunnerLoading && (
+        <div style={{ fontSize: 12, color: '#595653', marginBottom: 10 }}>
+          No todo runs yet.
+        </div>
+      )}
+
+      {todoRunnerDrafts.map((job) => {
+        const busy = todoRunnerBusyId === job.id
+        const statusColor =
+          job.lastStatus === 'success'
+            ? '#548C5A'
+            : job.lastStatus === 'error'
+              ? '#c45050'
+              : job.lastStatus === 'running'
+                ? '#d4a040'
+                : '#74747C'
+
+        return (
+          <div
+            key={job.id}
+            style={{
+              border: '1px solid rgba(89,86,83,0.25)',
+              borderRadius: 8,
+              padding: 10,
+              marginBottom: 10,
+              background: 'rgba(14,14,13,0.35)',
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+              <input
+                type="text"
+                value={job.name}
+                onChange={(e) => updateTodoRunnerDraft(job.id, { name: e.target.value })}
+                placeholder="Todo run name"
+                style={{
+                  flex: 1,
+                  background: 'rgba(89,86,83,0.15)',
+                  border: '1px solid rgba(89,86,83,0.3)',
+                  borderRadius: 6,
+                  padding: '5px 8px',
+                  fontSize: 13,
+                  color: '#9A9692',
+                  outline: 'none',
+                  fontFamily: 'inherit',
+                }}
+              />
+              <Toggle
+                checked={job.enabled}
+                onChange={(enabled) => updateTodoRunnerDraft(job.id, { enabled })}
+              />
+            </div>
+
+            <Row label="Directory">
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <input
+                  type="text"
+                  value={job.workingDirectory}
+                  onChange={(e) => updateTodoRunnerDraft(job.id, { workingDirectory: e.target.value })}
+                  placeholder="/path/to/project"
+                  style={{
+                    width: 220,
+                    background: 'rgba(89,86,83,0.15)',
+                    border: '1px solid rgba(89,86,83,0.3)',
+                    borderRadius: 6,
+                    padding: '5px 8px',
+                    fontSize: 13,
+                    color: '#9A9692',
+                    outline: 'none',
+                    fontFamily: 'inherit',
+                  }}
+                />
+                <button
+                  onClick={() => void browseTodoRunnerDirectory(job.id)}
+                  style={{
+                    padding: '5px 10px',
+                    fontSize: 12,
+                    fontWeight: 500,
+                    background: 'rgba(89,86,83,0.15)',
+                    border: '1px solid rgba(89,86,83,0.3)',
+                    borderRadius: 6,
+                    color: '#9A9692',
+                    cursor: 'pointer',
+                    fontFamily: 'inherit',
+                  }}
+                >
+                  Browse...
+                </button>
+              </div>
+            </Row>
+
+            <Row label="Runner command">
+              <input
+                type="text"
+                value={job.runnerCommand}
+                onChange={(e) => updateTodoRunnerDraft(job.id, { runnerCommand: e.target.value })}
+                placeholder="python3 /path/to/agent_sdk_worker.py"
+                style={{
+                  width: 320,
+                  background: 'rgba(89,86,83,0.15)',
+                  border: '1px solid rgba(89,86,83,0.3)',
+                  borderRadius: 6,
+                  padding: '5px 8px',
+                  fontSize: 12,
+                  color: '#9A9692',
+                  outline: 'none',
+                  fontFamily: 'inherit',
+                }}
+              />
+            </Row>
+
+            <Row label="YOLO mode">
+              <Toggle
+                checked={job.yoloMode}
+                onChange={(yoloMode) => updateTodoRunnerDraft(job.id, { yoloMode })}
+              />
+            </Row>
+
+            <div style={{ marginTop: 8 }}>
+              <div style={{ fontSize: 10, color: '#74747C', marginBottom: 4, letterSpacing: 0.8 }}>
+                GLOBAL PROMPT
+              </div>
+              <textarea
+                value={job.prompt}
+                onChange={(e) => updateTodoRunnerDraft(job.id, { prompt: e.target.value })}
+                placeholder="Instructions applied to every todo item run"
+                rows={3}
+                style={{
+                  width: '100%',
+                  background: 'rgba(89,86,83,0.15)',
+                  border: '1px solid rgba(89,86,83,0.3)',
+                  borderRadius: 6,
+                  padding: '7px 8px',
+                  fontSize: 12,
+                  color: '#9A9692',
+                  outline: 'none',
+                  fontFamily: 'inherit',
+                  resize: 'vertical',
+                  lineHeight: 1.45,
+                }}
+              />
+            </div>
+
+            <div style={{ marginTop: 8 }}>
+              <div style={{ fontSize: 10, color: '#74747C', marginBottom: 4, letterSpacing: 0.8 }}>
+                TODO ITEMS (one per line)
+              </div>
+              <textarea
+                value={job.todoItemsText}
+                onChange={(e) => updateTodoRunnerDraft(job.id, { todoItemsText: e.target.value })}
+                placeholder="Todo #1&#10;Todo #2&#10;Todo #3"
+                rows={8}
+                style={{
+                  width: '100%',
+                  background: 'rgba(89,86,83,0.15)',
+                  border: '1px solid rgba(89,86,83,0.3)',
+                  borderRadius: 6,
+                  padding: '7px 8px',
+                  fontSize: 12,
+                  color: '#9A9692',
+                  outline: 'none',
+                  fontFamily: 'inherit',
+                  resize: 'vertical',
+                  lineHeight: 1.45,
+                }}
+              />
+            </div>
+
+            <div style={{ marginTop: 8, fontSize: 11, color: '#74747C', lineHeight: 1.5 }}>
+              <div>
+                Status:{' '}
+                <span style={{ color: statusColor, fontWeight: 600 }}>
+                  {job.isRunning ? 'running' : job.lastStatus}
+                </span>
+              </div>
+              <div>
+                Progress: {job.completedTodos}/{job.totalTodos} complete
+                {job.failedTodos > 0 ? `, ${job.failedTodos} failed` : ''}
+                {job.blockedTodos > 0 ? `, ${job.blockedTodos} blocked` : ''}
+              </div>
+              <div>
+                Current todo: {job.currentTodoIndex != null ? String(job.currentTodoIndex + 1) : 'None'}
+              </div>
+              <div>Next todo: {job.nextTodoText ?? 'None'}</div>
+              <div>
+                Last run: {formatDateTime(job.lastRunAt)}
+                {job.lastDurationMs != null ? ` (${formatDuration(job.lastDurationMs)})` : ''}
+              </div>
+              {job.lastError && (
+                <div style={{ color: '#c45050' }}>Last error: {job.lastError}</div>
+              )}
+            </div>
+
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 10 }}>
+              {!job.isDraft && (
+                <>
+                  <button
+                    onClick={() => void startTodoRunnerJob(job)}
+                    disabled={busy}
+                    style={{
+                      padding: '5px 10px',
+                      fontSize: 12,
+                      fontWeight: 500,
+                      background: 'rgba(84,140,90,0.14)',
+                      border: '1px solid rgba(84,140,90,0.35)',
+                      borderRadius: 6,
+                      color: '#7fb887',
+                      cursor: busy ? 'default' : 'pointer',
+                      fontFamily: 'inherit',
+                      opacity: busy ? 0.5 : 1,
+                    }}
+                  >
+                    Start
+                  </button>
+                  <button
+                    onClick={() => void pauseTodoRunnerJob(job)}
+                    disabled={busy}
+                    style={{
+                      padding: '5px 10px',
+                      fontSize: 12,
+                      fontWeight: 500,
+                      background: 'rgba(212,160,64,0.12)',
+                      border: '1px solid rgba(212,160,64,0.35)',
+                      borderRadius: 6,
+                      color: '#d4a040',
+                      cursor: busy ? 'default' : 'pointer',
+                      fontFamily: 'inherit',
+                      opacity: busy ? 0.5 : 1,
+                    }}
+                  >
+                    Pause
+                  </button>
+                  <button
+                    onClick={() => void resetTodoRunnerJob(job)}
+                    disabled={busy}
+                    style={{
+                      padding: '5px 10px',
+                      fontSize: 12,
+                      fontWeight: 500,
+                      background: 'rgba(89,86,83,0.15)',
+                      border: '1px solid rgba(89,86,83,0.3)',
+                      borderRadius: 6,
+                      color: '#9A9692',
+                      cursor: busy ? 'default' : 'pointer',
+                      fontFamily: 'inherit',
+                      opacity: busy ? 0.5 : 1,
+                    }}
+                  >
+                    Reset Progress
+                  </button>
+                </>
+              )}
+              <button
+                onClick={() => void saveTodoRunnerJob(job)}
+                disabled={busy}
+                style={{
+                  padding: '5px 10px',
+                  fontSize: 12,
+                  fontWeight: 500,
+                  background: 'rgba(89,86,83,0.15)',
+                  border: '1px solid rgba(89,86,83,0.3)',
+                  borderRadius: 6,
+                  color: '#9A9692',
+                  cursor: busy ? 'default' : 'pointer',
+                  fontFamily: 'inherit',
+                  opacity: busy ? 0.5 : 1,
+                }}
+              >
+                Save
+              </button>
+              <button
+                onClick={() => void removeTodoRunnerJob(job)}
+                disabled={busy}
+                style={{
+                  padding: '5px 10px',
+                  fontSize: 12,
+                  fontWeight: 500,
+                  background: 'rgba(196,80,80,0.12)',
+                  border: '1px solid rgba(196,80,80,0.32)',
+                  borderRadius: 6,
+                  color: '#c45050',
+                  cursor: busy ? 'default' : 'pointer',
+                  fontFamily: 'inherit',
+                  opacity: busy ? 0.5 : 1,
+                }}
+              >
+                {job.isDraft ? 'Discard' : 'Delete'}
+              </button>
+            </div>
+          </div>
+        )
+      })}
+
+      <button
+        onClick={addTodoRunnerDraft}
+        style={{
+          marginTop: 4,
+          padding: '5px 12px',
+          fontSize: 12,
+          fontWeight: 500,
+          background: 'rgba(89,86,83,0.15)',
+          border: '1px solid rgba(89,86,83,0.3)',
+          borderRadius: 6,
+          color: '#9A9692',
+          cursor: 'pointer',
+          fontFamily: 'inherit',
+        }}
+      >
+        + Add Todo Run
+      </button>
+    </Section>
+  )
+}

--- a/src/renderer/components/settings/common.tsx
+++ b/src/renderer/components/settings/common.tsx
@@ -1,0 +1,105 @@
+import type React from 'react'
+
+export function Toggle({ checked, onChange }: { checked: boolean; onChange: (v: boolean) => void }) {
+  return (
+    <button
+      type="button"
+      onClick={() => onChange(!checked)}
+      style={{
+        position: 'relative', width: 36, height: 20, borderRadius: 10, border: 'none', cursor: 'pointer',
+        background: checked ? '#548C5A' : 'rgba(89,86,83,0.3)', transition: 'background 0.2s ease',
+      }}
+    >
+      <span
+        style={{
+          position: 'absolute', top: 2, left: checked ? 18 : 2,
+          width: 16, height: 16, borderRadius: '50%', background: '#9A9692',
+          transition: 'left 0.2s ease',
+        }}
+      />
+    </button>
+  )
+}
+
+export function Select({
+  value,
+  options,
+  labels,
+  onChange,
+}: {
+  value: string
+  options: string[]
+  labels?: Record<string, string>
+  onChange: (v: string) => void
+}) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      style={{
+        background: 'rgba(89,86,83,0.15)', border: '1px solid rgba(89,86,83,0.3)',
+        borderRadius: 6, padding: '5px 8px', fontSize: 13, color: '#9A9692',
+        outline: 'none', fontFamily: 'inherit', minWidth: 160,
+      }}
+    >
+      {options.map((opt) => (
+        <option key={opt} value={opt} style={{ background: '#0E0E0D' }}>
+          {labels?.[opt] ?? opt}
+        </option>
+      ))}
+    </select>
+  )
+}
+
+export function NumberInput({
+  value,
+  min,
+  max,
+  step,
+  onChange,
+}: {
+  value: number
+  min?: number
+  max?: number
+  step?: number
+  onChange: (v: number) => void
+}) {
+  return (
+    <input
+      type="number"
+      value={value}
+      min={min}
+      max={max}
+      step={step}
+      onChange={(e) => {
+        const parsed = Number(e.target.value)
+        if (!isNaN(parsed) && parsed >= (min ?? 0) && parsed <= (max ?? Infinity)) {
+          onChange(parsed)
+        }
+      }}
+      style={{
+        background: 'rgba(89,86,83,0.15)', border: '1px solid rgba(89,86,83,0.3)',
+        borderRadius: 6, padding: '5px 8px', fontSize: 13, color: '#9A9692',
+        outline: 'none', fontFamily: 'inherit', width: 80,
+      }}
+    />
+  )
+}
+
+export function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '8px 0' }}>
+      <span style={{ fontSize: 13, color: '#9A9692' }}>{label}</span>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>{children}</div>
+    </div>
+  )
+}
+
+export function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div style={{ marginBottom: 18 }}>
+      <div style={{ fontSize: 10, fontWeight: 600, letterSpacing: 1, color: '#74747C', marginBottom: 8 }}>{title}</div>
+      <div>{children}</div>
+    </div>
+  )
+}

--- a/src/renderer/components/settings/types.ts
+++ b/src/renderer/components/settings/types.ts
@@ -1,0 +1,4 @@
+import type { SchedulerTask, TodoRunnerJob } from '../../types'
+
+export type SchedulerTaskDraft = SchedulerTask & { isDraft?: boolean }
+export type TodoRunnerJobDraft = TodoRunnerJob & { isDraft?: boolean; todoItemsText: string }

--- a/src/renderer/components/settings/useSettingsDraft.ts
+++ b/src/renderer/components/settings/useSettingsDraft.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState, type Dispatch, type SetStateAction } from 'react'
+import type { AppSettings } from '../../types'
+
+export function useSettingsDraft(
+  isOpen: boolean,
+  currentSettings: AppSettings
+): [AppSettings, Dispatch<SetStateAction<AppSettings>>] {
+  const [draft, setDraft] = useState<AppSettings>(currentSettings)
+
+  useEffect(() => {
+    if (isOpen) setDraft(currentSettings)
+  }, [isOpen, currentSettings])
+
+  return [draft, setDraft]
+}

--- a/src/renderer/components/settings/utils.ts
+++ b/src/renderer/components/settings/utils.ts
@@ -1,0 +1,34 @@
+export function formatDateTime(timestamp: number | null): string {
+  if (!timestamp) return 'Never'
+  return new Date(timestamp).toLocaleString()
+}
+
+export function formatDuration(durationMs: number | null): string {
+  if (!durationMs || durationMs <= 0) return '0s'
+  const seconds = Math.round(durationMs / 1000)
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  const remainderSeconds = seconds % 60
+  if (minutes < 60) return `${minutes}m ${remainderSeconds}s`
+  const hours = Math.floor(minutes / 60)
+  const remainderMinutes = minutes % 60
+  return `${hours}h ${remainderMinutes}m`
+}
+
+export function parseCsv(value: string): string[] {
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+}
+
+export function todoItemsToText(items: string[]): string {
+  return items.join('\n')
+}
+
+export function todoItemsFromText(value: string): string[] {
+  return value
+    .split('\n')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+}


### PR DESCRIPTION
## Summary
- extract shared settings UI primitives and utility helpers into `src/renderer/components/settings/`
- add dedicated `SchedulerTab` and `TodoRunnerTab` components and wire `SettingsPanel` to use them
- introduce `useSettingsDraft` hook to isolate modal draft sync behavior

## Validation
- `pnpm lint:desktop`
- `pnpm typecheck`

Closes #91

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a UI refactor/extraction with minimal behavioral change; main risk is regressions in settings draft syncing or schedules/todo-runner tab wiring.
> 
> **Overview**
> `SettingsPanel` is refactored to be more modular by extracting the **Schedules** and **Todo Runner** sections into new `SchedulerTab` and `TodoRunnerTab` components, and by moving shared UI primitives (`Toggle`, `Select`, `NumberInput`, `Row`, `Section`) and small helpers (date/duration formatting, CSV + todo text parsing) into `components/settings/*` modules.
> 
> Draft-sync behavior for the modal is isolated into a new `useSettingsDraft` hook (now also responds to `currentSettings` changes), and the panel is rewired to consume the new types (`SchedulerTaskDraft`, `TodoRunnerJobDraft`) and utility functions from the extracted modules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea3d9ea6d3f62cc991c6ce8d572319df17152e71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->