### PR TITLE
Extract shared job editor abstractions for Schedules and Todo Runner

### DIFF
--- a/src/renderer/components/settings/SchedulerTab.tsx
+++ b/src/renderer/components/settings/SchedulerTab.tsx
@@ -1,5 +1,5 @@
 import { Row, Section, Toggle } from './common'
-import { formatDateTime, formatDuration } from './utils'
+import { formatDateTime, formatDuration, runStatusColor } from './utils'
 import type { SchedulerTaskDraft } from './types'
 
 const DEFAULT_CRON_EXAMPLES = ['*/15 * * * *', '0 * * * *', '0 9 * * 1-5', '30 18 * * *']
@@ -82,14 +82,7 @@ export function SchedulerTab({
 
       {scheduleDrafts.map((task) => {
         const busy = schedulerBusyId === task.id
-        const statusColor =
-          task.lastStatus === 'success'
-            ? '#548C5A'
-            : task.lastStatus === 'error'
-              ? '#c45050'
-              : task.lastStatus === 'running'
-                ? '#d4a040'
-                : '#74747C'
+        const statusColor = runStatusColor(task.lastStatus, task.isRunning)
 
         return (
           <div

--- a/src/renderer/components/settings/TodoRunnerTab.tsx
+++ b/src/renderer/components/settings/TodoRunnerTab.tsx
@@ -1,5 +1,5 @@
 import { Row, Section, Toggle } from './common'
-import { formatDateTime, formatDuration } from './utils'
+import { formatDateTime, formatDuration, runStatusColor } from './utils'
 import type { TodoRunnerJobDraft } from './types'
 
 interface TodoRunnerTabProps {
@@ -73,14 +73,7 @@ export function TodoRunnerTab({
 
       {todoRunnerDrafts.map((job) => {
         const busy = todoRunnerBusyId === job.id
-        const statusColor =
-          job.lastStatus === 'success'
-            ? '#548C5A'
-            : job.lastStatus === 'error'
-              ? '#c45050'
-              : job.lastStatus === 'running'
-                ? '#d4a040'
-                : '#74747C'
+        const statusColor = runStatusColor(job.lastStatus, job.isRunning)
 
         return (
           <div

--- a/src/renderer/components/settings/useJobAction.ts
+++ b/src/renderer/components/settings/useJobAction.ts
@@ -1,0 +1,31 @@
+import { useCallback, type Dispatch, type SetStateAction } from 'react'
+
+interface JobWithId {
+  id: string
+}
+
+interface UseJobActionOptions {
+  setBusyId: Dispatch<SetStateAction<string | null>>
+  setError: Dispatch<SetStateAction<string | null>>
+  reload: () => Promise<void>
+}
+
+export function useJobAction<T extends JobWithId>({
+  setBusyId,
+  setError,
+  reload,
+}: UseJobActionOptions): (entry: T, action: () => Promise<void>) => Promise<void> {
+  return useCallback(async (entry: T, action: () => Promise<void>) => {
+    try {
+      setBusyId(entry.id)
+      setError(null)
+      await action()
+      await reload()
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      setError(message)
+    } finally {
+      setBusyId(null)
+    }
+  }, [reload, setBusyId, setError])
+}

--- a/src/renderer/components/settings/utils.ts
+++ b/src/renderer/components/settings/utils.ts
@@ -15,6 +15,16 @@ export function formatDuration(durationMs: number | null): string {
   return `${hours}h ${remainderMinutes}m`
 }
 
+export function runStatusColor(
+  lastStatus: 'idle' | 'running' | 'success' | 'error',
+  isRunning: boolean
+): string {
+  if (isRunning || lastStatus === 'running') return '#d4a040'
+  if (lastStatus === 'success') return '#548C5A'
+  if (lastStatus === 'error') return '#c45050'
+  return '#74747C'
+}
+
 export function parseCsv(value: string): string[] {
   return value
     .split(',')


### PR DESCRIPTION
## Summary
- add a shared `useJobAction` hook to unify busy/error/reload mutation flow for scheduler and todo-runner actions
- replace duplicated `try/catch/finally` blocks in `SettingsPanel` with the shared hook
- centralize automation status color logic in `runStatusColor` and reuse it across `SchedulerTab` and `TodoRunnerTab`

## Validation
- `pnpm lint:desktop`
- `pnpm typecheck`

Closes #92

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a UI/refactor change that consolidates duplicated async error/busy handling and a small status-color utility; low risk aside from potential regressions in action-state updates.
> 
> **Overview**
> Refactors the Schedules and Todo Runner editors to share mutation handling and status rendering.
> 
> Adds a reusable `useJobAction` hook and updates `SettingsPanel` to run scheduler/todo-runner actions through it, consolidating the busy-id, error reset/reporting, and post-mutation reload flow. Also centralizes run status color selection in `runStatusColor` and reuses it in `SchedulerTab` and `TodoRunnerTab` (now considering `isRunning` as well as `lastStatus`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c478c12b8d44ac934c30eb44866a33ab9deb9d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->