### PR TITLE
refactor: decompose ChatPanel Claude event handling

### DIFF
--- a/src/renderer/components/chat/claudeEventHandlers.ts
+++ b/src/renderer/components/chat/claudeEventHandlers.ts
@@ -1,0 +1,384 @@
+import { randomAppearance } from '../../types'
+import type {
+  Agent,
+  AgentEvent,
+  ChatMessage,
+  ClaudeErrorInfo,
+  ClaudeEvent,
+  ClaudeEventType,
+  ClaudeSessionResult,
+  ClaudeThinkingContent,
+  ClaudeToolResult,
+  ClaudeToolUse,
+  ClaudeTextContent,
+  PluginHookEvent,
+  PluginHookEventPayloadMap,
+} from '../../types'
+
+export type SessionStatus = 'idle' | 'running' | 'done' | 'error'
+
+type MessageUpdater = (updater: (previous: ChatMessage[]) => ChatMessage[]) => void
+
+export interface ClaudeEventHandlerContext {
+  chatSessionId: string
+  workingDirectory: string | null
+  getAgentId: () => string | null
+  getActiveRunDirectory: () => string | null
+  setMessages: MessageUpdater
+  setStatus: (status: SessionStatus) => void
+  updateAgent: (id: string, updates: Partial<Agent>) => void
+  addEvent: (event: Omit<AgentEvent, 'id' | 'timestamp'>) => void
+  addAgent: (agent: Agent) => void
+  removeAgent: (idOrTerminalId: string) => void
+  clearSubagentsForParent: (parentAgentId: string) => void
+  emitPluginHook: <E extends PluginHookEvent>(
+    event: E,
+    payload: PluginHookEventPayloadMap[E]
+  ) => Promise<void> | void
+  persistMessage: (
+    content: string,
+    role: string,
+    context?: { directory?: string | null; scopeId?: string; scopeName?: string }
+  ) => void
+  finalizeRunReward: (status: 'success' | 'error' | 'stopped') => void
+  resetRunState: () => void
+  playCompletionDing: () => void
+  nextMessageId: () => string
+  truncateForHook: (value: string, max?: number) => string
+  runToolCallCountRef: { current: number }
+  runFileWriteCountRef: { current: number }
+  subagentSeatCounterRef: { current: number }
+  activeSubagents: Map<string, string>
+  activeToolNames: Map<string, string>
+  incrementAgentFileCount: (agentId: string) => void
+  getChatAgentName: () => string
+}
+
+export type ClaudeEventHandler = (event: ClaudeEvent) => void
+export type ClaudeEventHandlerRegistry = Record<ClaudeEventType, ClaudeEventHandler>
+
+function getHookWorkspaceDirectory(context: ClaudeEventHandlerContext): string | null {
+  return context.getActiveRunDirectory() ?? context.workingDirectory ?? null
+}
+
+function appendMessage(context: ClaudeEventHandlerContext, message: ChatMessage): void {
+  context.setMessages((previous) => [...previous, message])
+}
+
+function removeThinkingMessages(context: ClaudeEventHandlerContext): void {
+  context.setMessages((previous) => previous.filter((message) => message.role !== 'thinking'))
+}
+
+function handleInit(event: ClaudeEvent, context: ClaudeEventHandlerContext): void {
+  void event
+  const agentId = context.getAgentId()
+  if (!agentId) return
+  context.updateAgent(agentId, { status: 'thinking' })
+}
+
+function handleText(event: ClaudeEvent, context: ClaudeEventHandlerContext): void {
+  const data = event.data as ClaudeTextContent
+  if (!data.text) return
+
+  context.setMessages((previous) => {
+    const last = previous[previous.length - 1]
+    if (last && last.role === 'assistant' && !last.toolName) {
+      return [
+        ...previous.slice(0, -1),
+        { ...last, content: last.content + data.text },
+      ]
+    }
+    return [
+      ...previous,
+      {
+        id: context.nextMessageId(),
+        role: 'assistant',
+        content: data.text,
+        timestamp: Date.now(),
+      },
+    ]
+  })
+
+  const agentId = context.getAgentId()
+  if (!agentId) return
+  context.updateAgent(agentId, { status: 'streaming' })
+}
+
+function handleThinking(event: ClaudeEvent, context: ClaudeEventHandlerContext): void {
+  const data = event.data as ClaudeThinkingContent
+  context.setMessages((previous) => {
+    const withoutThinking = previous.filter((message) => message.role !== 'thinking')
+    return [
+      ...withoutThinking,
+      {
+        id: context.nextMessageId(),
+        role: 'thinking',
+        content: data.thinking?.slice(0, 200) ?? 'Thinking...',
+        timestamp: Date.now(),
+      },
+    ]
+  })
+
+  const agentId = context.getAgentId()
+  if (!agentId) return
+  context.updateAgent(agentId, { status: 'thinking' })
+}
+
+function handleToolUse(event: ClaudeEvent, context: ClaudeEventHandlerContext): void {
+  const data = event.data as ClaudeToolUse
+  const agentId = context.getAgentId()
+  context.runToolCallCountRef.current += 1
+  context.activeToolNames.set(data.id, data.name)
+
+  void context.emitPluginHook('before_tool_call', {
+    chatSessionId: context.chatSessionId,
+    workspaceDirectory: getHookWorkspaceDirectory(context),
+    agentId,
+    timestamp: Date.now(),
+    toolName: data.name,
+    toolUseId: data.id,
+    toolInput: data.input,
+  })
+
+  context.setMessages((previous) => [
+    ...previous.filter((message) => message.role !== 'thinking'),
+    {
+      id: context.nextMessageId(),
+      role: 'assistant',
+      content: '',
+      timestamp: Date.now(),
+      toolName: data.name,
+      toolInput: data.input,
+      toolUseId: data.id,
+    },
+  ])
+
+  if (!agentId) return
+
+  context.updateAgent(agentId, { status: 'tool_calling', currentTask: data.name })
+  context.addEvent({
+    agentId,
+    agentName: context.getChatAgentName(),
+    type: 'tool_call',
+    description: data.name,
+  })
+
+  const fileTools = ['Write', 'Edit', 'MultiEdit', 'NotebookEdit']
+  if (fileTools.includes(data.name)) {
+    context.runFileWriteCountRef.current += 1
+    context.incrementAgentFileCount(agentId)
+  }
+
+  if (data.name !== 'Task') return
+
+  const subId = `sub-${agentId}-${data.id}`
+  const seat = context.subagentSeatCounterRef.current++
+  const input = data.input as Record<string, unknown>
+  const subDescription = (input.description as string)
+    ?? (input.prompt as string)?.slice(0, 60)
+    ?? 'Subtask'
+  const subType = (input.subagent_type as string) ?? 'general'
+
+  context.activeSubagents.set(data.id, subId)
+  context.addAgent({
+    id: subId,
+    name: subType.charAt(0).toUpperCase() + subType.slice(1),
+    agent_type: 'mcp',
+    status: 'thinking',
+    currentTask: subDescription.slice(0, 60),
+    model: '',
+    tokens_input: 0,
+    tokens_output: 0,
+    files_modified: 0,
+    started_at: Date.now(),
+    deskIndex: -1,
+    terminalId: subId,
+    isClaudeRunning: true,
+    appearance: randomAppearance(),
+    commitCount: 0,
+    activeCelebration: null,
+    celebrationStartedAt: null,
+    sessionStats: {
+      tokenHistory: [],
+      peakInputRate: 0,
+      peakOutputRate: 0,
+      tokensByModel: {},
+    },
+    isSubagent: true,
+    parentAgentId: agentId,
+    meetingSeat: seat,
+  })
+
+  context.addEvent({
+    agentId: subId,
+    agentName: subType,
+    type: 'spawn',
+    description: `Subagent: ${subDescription.slice(0, 40)}`,
+  })
+}
+
+function handleToolResult(event: ClaudeEvent, context: ClaudeEventHandlerContext): void {
+  const data = event.data as ClaudeToolResult
+  const agentId = context.getAgentId()
+  const toolName = context.activeToolNames.get(data.tool_use_id) ?? null
+  context.activeToolNames.delete(data.tool_use_id)
+
+  void context.emitPluginHook('after_tool_call', {
+    chatSessionId: context.chatSessionId,
+    workspaceDirectory: getHookWorkspaceDirectory(context),
+    agentId,
+    timestamp: Date.now(),
+    toolUseId: data.tool_use_id,
+    isError: data.is_error === true,
+    contentPreview: context.truncateForHook(data.content, 240),
+  })
+  void context.emitPluginHook('tool_result_persist', {
+    chatSessionId: context.chatSessionId,
+    workspaceDirectory: getHookWorkspaceDirectory(context),
+    agentId,
+    timestamp: Date.now(),
+    toolName,
+    toolUseId: data.tool_use_id,
+    isError: data.is_error === true,
+    contentPreview: context.truncateForHook(data.content, 240),
+    contentLength: data.content.length,
+  })
+
+  appendMessage(context, {
+    id: context.nextMessageId(),
+    role: 'tool',
+    content: data.content,
+    timestamp: Date.now(),
+    toolUseId: data.tool_use_id,
+    isError: data.is_error,
+  })
+
+  const subId = context.activeSubagents.get(data.tool_use_id)
+  if (subId) {
+    context.updateAgent(subId, {
+      status: data.is_error ? 'error' : 'done',
+      isClaudeRunning: false,
+    })
+    context.activeSubagents.delete(data.tool_use_id)
+    setTimeout(() => {
+      context.removeAgent(subId)
+    }, 5000)
+  }
+
+  if (!agentId) return
+  context.updateAgent(agentId, { status: 'streaming' })
+}
+
+function handleResult(event: ClaudeEvent, context: ClaudeEventHandlerContext): void {
+  const data = event.data as ClaudeSessionResult
+  const agentId = context.getAgentId()
+  removeThinkingMessages(context)
+
+  context.setMessages((previous) => {
+    const assistantMessages = previous.filter((message) => message.role === 'assistant' && !message.toolName)
+    const lastAssistant = assistantMessages[assistantMessages.length - 1]
+    if (lastAssistant?.content) {
+      const activeRunDirectory = context.getActiveRunDirectory()
+      queueMicrotask(() => {
+        context.persistMessage(lastAssistant.content, 'assistant', { directory: activeRunDirectory })
+        void context.emitPluginHook('message_sent', {
+          chatSessionId: context.chatSessionId,
+          workspaceDirectory: activeRunDirectory ?? context.workingDirectory ?? null,
+          agentId,
+          timestamp: Date.now(),
+          role: 'assistant',
+          message: context.truncateForHook(lastAssistant.content),
+          messageLength: lastAssistant.content.length,
+        })
+      })
+    }
+    return previous
+  })
+
+  if (data.is_error && data.error) {
+    void context.emitPluginHook('message_sent', {
+      chatSessionId: context.chatSessionId,
+      workspaceDirectory: getHookWorkspaceDirectory(context),
+      agentId,
+      timestamp: Date.now(),
+      role: 'error',
+      message: context.truncateForHook(data.error),
+      messageLength: data.error.length,
+    })
+    appendMessage(context, {
+      id: context.nextMessageId(),
+      role: 'error',
+      content: data.error ?? 'Unknown error',
+      timestamp: Date.now(),
+    })
+    context.setStatus('error')
+  } else {
+    context.setStatus('done')
+    context.playCompletionDing()
+  }
+
+  if (agentId) {
+    context.updateAgent(agentId, {
+      status: data.is_error ? 'error' : 'done',
+      isClaudeRunning: false,
+    })
+    context.clearSubagentsForParent(agentId)
+  }
+
+  context.finalizeRunReward(data.is_error ? 'error' : 'success')
+  context.resetRunState()
+}
+
+function handleError(event: ClaudeEvent, context: ClaudeEventHandlerContext): void {
+  const data = event.data as ClaudeErrorInfo
+  const agentId = context.getAgentId()
+  void context.emitPluginHook('message_sent', {
+    chatSessionId: context.chatSessionId,
+    workspaceDirectory: getHookWorkspaceDirectory(context),
+    agentId,
+    timestamp: Date.now(),
+    role: 'error',
+    message: context.truncateForHook(data.message),
+    messageLength: data.message.length,
+  })
+
+  context.setMessages((previous) => [
+    ...previous.filter((message) => message.role !== 'thinking'),
+    {
+      id: context.nextMessageId(),
+      role: 'error',
+      content: data.message,
+      timestamp: Date.now(),
+    },
+  ])
+  context.setStatus('error')
+
+  if (agentId) {
+    context.updateAgent(agentId, { status: 'error', isClaudeRunning: false })
+    context.clearSubagentsForParent(agentId)
+  }
+
+  context.finalizeRunReward('error')
+  context.resetRunState()
+}
+
+export function createClaudeEventHandlerRegistry(
+  context: ClaudeEventHandlerContext
+): ClaudeEventHandlerRegistry {
+  return {
+    init: (event) => handleInit(event, context),
+    text: (event) => handleText(event, context),
+    thinking: (event) => handleThinking(event, context),
+    tool_use: (event) => handleToolUse(event, context),
+    tool_result: (event) => handleToolResult(event, context),
+    result: (event) => handleResult(event, context),
+    error: (event) => handleError(event, context),
+  }
+}
+
+export function routeClaudeEvent(
+  event: ClaudeEvent,
+  registry: ClaudeEventHandlerRegistry
+): void {
+  registry[event.type](event)
+}

--- a/tests/smoke/chat-event-handlers.spec.ts
+++ b/tests/smoke/chat-event-handlers.spec.ts
@@ -1,0 +1,237 @@
+import { expect, test } from '@playwright/test'
+import type {
+  Agent,
+  AgentEvent,
+  ChatMessage,
+  ClaudeEvent,
+  PluginHookEvent,
+  PluginHookEventPayloadMap,
+} from '../../src/renderer/types'
+import {
+  createClaudeEventHandlerRegistry,
+  routeClaudeEvent,
+  type ClaudeEventHandlerContext,
+  type SessionStatus,
+} from '../../src/renderer/components/chat/claudeEventHandlers'
+
+interface HarnessState {
+  messages: ChatMessage[]
+  status: SessionStatus
+  agentId: string | null
+  activeRunDirectory: string | null
+  runToolCallCountRef: { current: number }
+  runFileWriteCountRef: { current: number }
+  subagentSeatCounterRef: { current: number }
+  activeSubagents: Map<string, string>
+  activeToolNames: Map<string, string>
+  updateCalls: Array<{ id: string; updates: Partial<Agent> }>
+  addEventCalls: Array<Omit<AgentEvent, 'id' | 'timestamp'>>
+  addAgentCalls: Agent[]
+  removeAgentCalls: string[]
+  clearSubagentCalls: string[]
+  emitHookCalls: Array<{ event: PluginHookEvent; payload: Record<string, unknown> }>
+  persistCalls: Array<{ content: string; role: string; directory: string | null }>
+  finalizeCalls: Array<'success' | 'error' | 'stopped'>
+  resetRunStateCalls: number
+  playCompletionDingCalls: number
+  incrementAgentFileCountCalls: number
+}
+
+function createHarness(): {
+  state: HarnessState
+  dispatch: (event: ClaudeEvent) => void
+} {
+  let messageCounter = 0
+  const state: HarnessState = {
+    messages: [],
+    status: 'idle',
+    agentId: 'agent-1',
+    activeRunDirectory: '/tmp/workspace',
+    runToolCallCountRef: { current: 0 },
+    runFileWriteCountRef: { current: 0 },
+    subagentSeatCounterRef: { current: 0 },
+    activeSubagents: new Map(),
+    activeToolNames: new Map(),
+    updateCalls: [],
+    addEventCalls: [],
+    addAgentCalls: [],
+    removeAgentCalls: [],
+    clearSubagentCalls: [],
+    emitHookCalls: [],
+    persistCalls: [],
+    finalizeCalls: [],
+    resetRunStateCalls: 0,
+    playCompletionDingCalls: 0,
+    incrementAgentFileCountCalls: 0,
+  }
+
+  const context: ClaudeEventHandlerContext = {
+    chatSessionId: 'chat-smoke',
+    workingDirectory: '/tmp/workspace',
+    getAgentId: () => state.agentId,
+    getActiveRunDirectory: () => state.activeRunDirectory,
+    setMessages: (updater) => {
+      state.messages = updater(state.messages)
+    },
+    setStatus: (status) => {
+      state.status = status
+    },
+    updateAgent: (id, updates) => {
+      state.updateCalls.push({ id, updates })
+    },
+    addEvent: (event) => {
+      state.addEventCalls.push(event)
+    },
+    addAgent: (agent) => {
+      state.addAgentCalls.push(agent)
+    },
+    removeAgent: (idOrTerminalId) => {
+      state.removeAgentCalls.push(idOrTerminalId)
+    },
+    clearSubagentsForParent: (parentAgentId) => {
+      state.clearSubagentCalls.push(parentAgentId)
+    },
+    emitPluginHook: <E extends PluginHookEvent>(event: E, payload: PluginHookEventPayloadMap[E]) => {
+      state.emitHookCalls.push({ event, payload: payload as Record<string, unknown> })
+    },
+    persistMessage: (content, role, contextInfo) => {
+      state.persistCalls.push({
+        content,
+        role,
+        directory: contextInfo?.directory ?? null,
+      })
+    },
+    finalizeRunReward: (status) => {
+      state.finalizeCalls.push(status)
+    },
+    resetRunState: () => {
+      state.resetRunStateCalls += 1
+      state.activeRunDirectory = null
+    },
+    playCompletionDing: () => {
+      state.playCompletionDingCalls += 1
+    },
+    nextMessageId: () => `msg-${++messageCounter}`,
+    truncateForHook: (value, max = 500) => (value.length <= max ? value : `${value.slice(0, max)}…`),
+    runToolCallCountRef: state.runToolCallCountRef,
+    runFileWriteCountRef: state.runFileWriteCountRef,
+    subagentSeatCounterRef: state.subagentSeatCounterRef,
+    activeSubagents: state.activeSubagents,
+    activeToolNames: state.activeToolNames,
+    incrementAgentFileCount: () => {
+      state.incrementAgentFileCountCalls += 1
+    },
+    getChatAgentName: () => 'Chat 1',
+  }
+
+  const registry = createClaudeEventHandlerRegistry(context)
+  return {
+    state,
+    dispatch: (event: ClaudeEvent) => routeClaudeEvent(event, registry),
+  }
+}
+
+test('tool_use transition appends tool call message and updates runtime counters', () => {
+  const harness = createHarness()
+  harness.dispatch({
+    sessionId: 'session-1',
+    type: 'tool_use',
+    data: {
+      id: 'tool-1',
+      name: 'Write',
+      input: { file_path: 'README.md' },
+    },
+  })
+
+  expect(harness.state.runToolCallCountRef.current).toBe(1)
+  expect(harness.state.runFileWriteCountRef.current).toBe(1)
+  expect(harness.state.incrementAgentFileCountCalls).toBe(1)
+  expect(harness.state.activeToolNames.get('tool-1')).toBe('Write')
+  expect(harness.state.messages.at(-1)).toMatchObject({
+    role: 'assistant',
+    toolName: 'Write',
+    toolUseId: 'tool-1',
+  })
+})
+
+test('tool_result transition appends tool output and clears active tool tracking', () => {
+  const harness = createHarness()
+  harness.dispatch({
+    sessionId: 'session-1',
+    type: 'tool_use',
+    data: {
+      id: 'tool-1',
+      name: 'Edit',
+      input: { file_path: 'README.md' },
+    },
+  })
+  harness.dispatch({
+    sessionId: 'session-1',
+    type: 'tool_result',
+    data: {
+      tool_use_id: 'tool-1',
+      content: 'done',
+    },
+  })
+
+  expect(harness.state.activeToolNames.has('tool-1')).toBe(false)
+  expect(harness.state.messages.at(-1)).toMatchObject({
+    role: 'tool',
+    content: 'done',
+    toolUseId: 'tool-1',
+  })
+  expect(
+    harness.state.updateCalls.some((entry) => entry.updates.status === 'streaming')
+  ).toBe(true)
+})
+
+test('result transition finalizes successful run and persists final assistant content', async () => {
+  const harness = createHarness()
+  harness.state.messages = [
+    { id: 'msg-a', role: 'assistant', content: 'Final response', timestamp: Date.now() - 2 },
+    { id: 'msg-b', role: 'thinking', content: 'Thinking...', timestamp: Date.now() - 1 },
+  ]
+
+  harness.dispatch({
+    sessionId: 'session-1',
+    type: 'result',
+    data: {
+      result: 'ok',
+      is_error: false,
+    },
+  })
+  await Promise.resolve()
+
+  expect(harness.state.status).toBe('done')
+  expect(harness.state.playCompletionDingCalls).toBe(1)
+  expect(harness.state.finalizeCalls).toEqual(['success'])
+  expect(harness.state.resetRunStateCalls).toBe(1)
+  expect(harness.state.messages.some((message) => message.role === 'thinking')).toBe(false)
+  expect(harness.state.persistCalls[0]).toMatchObject({
+    content: 'Final response',
+    role: 'assistant',
+  })
+})
+
+test('error transition appends error message and finalizes run as failed', () => {
+  const harness = createHarness()
+  harness.state.messages = [
+    { id: 'msg-a', role: 'thinking', content: 'Thinking...', timestamp: Date.now() - 1 },
+  ]
+
+  harness.dispatch({
+    sessionId: 'session-1',
+    type: 'error',
+    data: {
+      message: 'boom',
+    },
+  })
+
+  expect(harness.state.status).toBe('error')
+  expect(harness.state.finalizeCalls).toEqual(['error'])
+  expect(harness.state.resetRunStateCalls).toBe(1)
+  expect(harness.state.messages.at(-1)).toMatchObject({
+    role: 'error',
+    content: 'boom',
+  })
+})


### PR DESCRIPTION
## Summary
- extract Claude event handling into a dedicated typed handler registry module
- replace the monolithic ChatPanel event switch with routing through focused handlers
- add smoke tests for critical Claude event transitions (`tool_use`, `tool_result`, `result`, `error`)

## Testing
- pnpm run lint:desktop
- pnpm run typecheck
- pnpm exec playwright test -c playwright.smoke.config.ts --workers=1

Closes #93

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors Claude streaming/tool event handling and run teardown logic; behavior should be equivalent but regressions could impact message rendering, subagent tracking, plugin hooks, or run finalization. Added smoke tests reduce (but don’t eliminate) risk across key event transitions.
> 
> **Overview**
> Refactors `ChatPanel` by replacing the large Claude event `switch` with a typed handler registry in new `claudeEventHandlers.ts`, routing `init`/`text`/`thinking`/`tool_use`/`tool_result`/`result`/`error` events through focused functions.
> 
> Centralizes run teardown via a new `resetRunState` helper and extracts file-modification counting into `incrementAgentFileCount`, while preserving existing side effects (message updates, agent/subagent lifecycle, tool tracking, plugin hook emissions, and reward finalization). Adds Playwright smoke tests covering critical event transitions (`tool_use`, `tool_result`, `result`, `error`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1398cbf5c9523a2580b0865151b48b583dfda387. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->