### PR TITLE
refactor: extract ChatPanel send flow into staged prompt pipeline

### DIFF
--- a/src/renderer/components/chat/chatPromptPipeline.ts
+++ b/src/renderer/components/chat/chatPromptPipeline.ts
@@ -1,0 +1,346 @@
+import type { WorkspaceContextSnapshot } from '../../types'
+import { buildWorkspaceContextPrompt } from '../../lib/workspaceContext'
+
+const BINARY_EXTENSIONS = new Set([
+  'png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'ico', 'svg', 'tiff', 'psd',
+  'pdf', 'zip', 'tar', 'gz', 'rar', '7z',
+  'mp3', 'mp4', 'wav', 'mov', 'avi', 'mkv', 'flac',
+  'exe', 'dll', 'so', 'dylib', 'wasm',
+  'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx',
+  'dmg', 'iso', 'bin',
+])
+const MENTION_PATTERN = /(?:^|\s)@{([^}\n]+)}|(?:^|\s)@([^\s@]+)/g
+const MAX_REFERENCED_FILES = 12
+
+export interface SlashCommandInput {
+  name: string
+  argsRaw: string
+  args: string[]
+}
+
+export interface MentionLookupHit {
+  path: string
+  name: string
+  isDirectory: boolean
+}
+
+export interface ResolvedMentionedFile {
+  mention: string
+  path: string
+  relPath: string
+}
+
+export interface MentionResolutionResult {
+  resolved: ResolvedMentionedFile[]
+  unresolved: string[]
+}
+
+export interface MentionReferencesStageResult {
+  prompt: string
+  referenceNotes: string[]
+  resolvedMentionCount: number
+  unresolvedMentionCount: number
+}
+
+export interface PrepareChatPromptInput {
+  message: string
+  workingDirectory: string
+  mentions?: string[]
+  files?: File[]
+}
+
+export interface PrepareChatPromptResult {
+  prompt: string
+  mentionTokens: string[]
+  workspaceSnapshot: WorkspaceContextSnapshot | null
+  resolvedMentionCount: number
+  unresolvedMentionCount: number
+}
+
+export interface PrepareChatPromptDependencies {
+  getWorkspaceSnapshot: (workingDirectory: string) => Promise<WorkspaceContextSnapshot>
+  upsertWorkspaceSnapshot: (snapshot: WorkspaceContextSnapshot) => void
+  onWorkspaceSnapshotError?: (error: unknown) => void
+  resolveMentionedFiles: (
+    rootDir: string,
+    mentions: string[]
+  ) => Promise<MentionResolutionResult>
+  readReferencedFile: (path: string) => Promise<{ content: string; truncated?: boolean }>
+}
+
+export function normalizeMentionPath(value: string): string {
+  return value
+    .trim()
+    .replace(/\\/g, '/')
+    .replace(/^\.\/+/, '')
+    .replace(/^\/+/, '')
+}
+
+function toForwardSlashes(value: string): string {
+  return value.replace(/\\/g, '/')
+}
+
+function toRelativePathIfInside(rootDir: string, absolutePath: string): string | null {
+  const normalizedRoot = toForwardSlashes(rootDir).replace(/\/+$/, '')
+  const normalizedPath = toForwardSlashes(absolutePath)
+  if (normalizedPath === normalizedRoot) return ''
+  if (normalizedPath.startsWith(`${normalizedRoot}/`)) {
+    return normalizedPath.slice(normalizedRoot.length + 1)
+  }
+  return null
+}
+
+export function extractMentionPaths(message: string): string[] {
+  const mentions: string[] = []
+  const seen = new Set<string>()
+  for (const match of message.matchAll(MENTION_PATTERN)) {
+    const raw = match[1] ?? match[2] ?? ''
+    const normalized = normalizeMentionPath(raw)
+    if (!normalized || seen.has(normalized)) continue
+    seen.add(normalized)
+    mentions.push(normalized)
+  }
+  return mentions
+}
+
+export function resolveMentionTokens(message: string, mentions?: string[]): string[] {
+  if (mentions && mentions.length > 0) return mentions
+  return extractMentionPaths(message)
+}
+
+export function parseSlashCommandInput(message: string): SlashCommandInput | null {
+  const trimmed = message.trim()
+  if (!trimmed.startsWith('/')) return null
+  if (trimmed.startsWith('//')) return null
+  const firstSpace = trimmed.indexOf(' ')
+  const token = firstSpace >= 0 ? trimmed.slice(1, firstSpace) : trimmed.slice(1)
+  const name = token.trim()
+  if (!name) return null
+  const argsRaw = firstSpace >= 0 ? trimmed.slice(firstSpace + 1).trim() : ''
+  return {
+    name,
+    argsRaw,
+    args: argsRaw ? argsRaw.split(/\s+/).filter(Boolean) : [],
+  }
+}
+
+export async function resolveMentionedFilesWithSearch(
+  rootDir: string,
+  mentions: string[],
+  search: (rootDir: string, query: string, limit: number) => Promise<MentionLookupHit[]>,
+  onLookupError?: (mention: string, error: unknown) => void
+): Promise<MentionResolutionResult> {
+  const normalizedMentions = Array.from(
+    new Set(mentions.map((mention) => normalizeMentionPath(mention).toLowerCase()))
+  )
+    .filter(Boolean)
+    .slice(0, MAX_REFERENCED_FILES)
+
+  if (normalizedMentions.length === 0) {
+    return { resolved: [], unresolved: [] }
+  }
+
+  const lookups = await Promise.all(
+    normalizedMentions.map(async (mention) => {
+      try {
+        const hits = await search(rootDir, mention, 25)
+        return { mention, hits }
+      } catch (error) {
+        onLookupError?.(mention, error)
+        return { mention, hits: [] as MentionLookupHit[] }
+      }
+    })
+  )
+
+  const resolved: ResolvedMentionedFile[] = []
+  const unresolved: string[] = []
+  const seenPaths = new Set<string>()
+
+  for (const { mention, hits } of lookups) {
+    let bestMatch: { path: string; relPath: string; score: number } | null = null
+
+    for (let index = 0; index < hits.length; index += 1) {
+      const hit = hits[index]
+      if (hit.isDirectory) continue
+
+      const relPathRaw = toRelativePathIfInside(rootDir, hit.path) ?? hit.name
+      const relPath = normalizeMentionPath(relPathRaw)
+      if (!relPath) continue
+
+      const relLower = relPath.toLowerCase()
+      const nameLower = hit.name.toLowerCase()
+      let score = 0
+
+      if (relLower === mention) score += 500
+      if (relLower.endsWith(`/${mention}`)) score += 320
+      if (nameLower === mention) score += 220
+      if (relLower.includes(mention)) score += 100
+      score += Math.max(0, 30 - index)
+
+      if (!bestMatch || score > bestMatch.score) {
+        bestMatch = { path: hit.path, relPath, score }
+      }
+    }
+
+    if (!bestMatch) {
+      unresolved.push(mention)
+      continue
+    }
+
+    if (seenPaths.has(bestMatch.path)) continue
+    seenPaths.add(bestMatch.path)
+    resolved.push({
+      mention,
+      path: bestMatch.path,
+      relPath: bestMatch.relPath,
+    })
+  }
+
+  return { resolved, unresolved }
+}
+
+export async function loadWorkspaceSnapshotStage(
+  workingDirectory: string,
+  deps: Pick<PrepareChatPromptDependencies, 'getWorkspaceSnapshot' | 'upsertWorkspaceSnapshot' | 'onWorkspaceSnapshotError'>
+): Promise<WorkspaceContextSnapshot | null> {
+  try {
+    const workspaceSnapshot = await deps.getWorkspaceSnapshot(workingDirectory)
+    deps.upsertWorkspaceSnapshot(workspaceSnapshot)
+    return workspaceSnapshot
+  } catch (error) {
+    deps.onWorkspaceSnapshotError?.(error)
+    return null
+  }
+}
+
+export async function applyMentionReferencesStage(input: {
+  prompt: string
+  mentionTokens: string[]
+  workingDirectory: string
+  resolveMentionedFiles: PrepareChatPromptDependencies['resolveMentionedFiles']
+  readReferencedFile: PrepareChatPromptDependencies['readReferencedFile']
+}): Promise<MentionReferencesStageResult> {
+  const { prompt, mentionTokens, workingDirectory, resolveMentionedFiles, readReferencedFile } = input
+  if (mentionTokens.length === 0) {
+    return {
+      prompt,
+      referenceNotes: [],
+      resolvedMentionCount: 0,
+      unresolvedMentionCount: 0,
+    }
+  }
+
+  const { resolved, unresolved } = await resolveMentionedFiles(workingDirectory, mentionTokens)
+  const referenceNotes: string[] = []
+  const referencedContents: string[] = []
+
+  for (const ref of resolved) {
+    try {
+      const fileData = await readReferencedFile(ref.path)
+      const safeText = fileData.content.replace(/\0/g, '')
+      referencedContents.push(`\n--- Referenced file: ${ref.relPath} ---\n${safeText}\n--- End: ${ref.relPath} ---`)
+      if (fileData.truncated) {
+        referenceNotes.push(`${ref.relPath} (truncated to 2MB preview)`)
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      referenceNotes.push(`${ref.relPath} (failed to read: ${errorMessage})`)
+    }
+  }
+
+  let nextPrompt = prompt
+  if (referencedContents.length > 0) {
+    nextPrompt = `${nextPrompt}\n\nReferenced files via @:${referencedContents.join('\n')}`
+  }
+
+  if (unresolved.length > 0) {
+    referenceNotes.push(`Unresolved @ references: ${unresolved.map((entry) => `@${entry}`).join(', ')}`)
+  }
+
+  return {
+    prompt: nextPrompt,
+    referenceNotes,
+    resolvedMentionCount: resolved.length,
+    unresolvedMentionCount: unresolved.length,
+  }
+}
+
+export async function applyAttachmentFilesStage(input: {
+  prompt: string
+  files?: File[]
+}): Promise<string> {
+  const { files } = input
+  if (!files || files.length === 0) {
+    return input.prompt
+  }
+
+  const fileContents: string[] = []
+  const binaryFiles: string[] = []
+
+  for (const file of files) {
+    try {
+      const ext = file.name.split('.').pop()?.toLowerCase() ?? ''
+      if (BINARY_EXTENSIONS.has(ext)) {
+        binaryFiles.push(file.name)
+        continue
+      }
+      const text = await file.text()
+      const safeText = text.replace(/\0/g, '')
+      fileContents.push(`\n--- File: ${file.name} ---\n${safeText}\n--- End: ${file.name} ---`)
+    } catch {
+      // Best effort only: failures should not block sending the prompt.
+    }
+  }
+
+  let nextPrompt = input.prompt
+  if (fileContents.length > 0) {
+    nextPrompt = `${nextPrompt}\n\nAttached files:${fileContents.join('\n')}`
+  }
+  if (binaryFiles.length > 0) {
+    nextPrompt = `${nextPrompt}\n\n[Attached binary files: ${binaryFiles.join(', ')} — binary content cannot be sent via CLI]`
+  }
+  return nextPrompt
+}
+
+export function applyReferenceNotesStage(prompt: string, referenceNotes: string[]): string {
+  if (referenceNotes.length === 0) return prompt
+  return `${prompt}\n\n[Reference notes: ${referenceNotes.join(' | ')}]`
+}
+
+export function applyWorkspaceContextStage(
+  prompt: string,
+  workspaceSnapshot: WorkspaceContextSnapshot | null
+): string {
+  if (!workspaceSnapshot) return prompt
+  return `${prompt}\n\n${buildWorkspaceContextPrompt(workspaceSnapshot)}`
+}
+
+export async function prepareChatPrompt(
+  input: PrepareChatPromptInput,
+  deps: PrepareChatPromptDependencies
+): Promise<PrepareChatPromptResult> {
+  const mentionTokens = resolveMentionTokens(input.message, input.mentions)
+  const workspaceSnapshot = await loadWorkspaceSnapshotStage(input.workingDirectory, deps)
+  const mentionStage = await applyMentionReferencesStage({
+    prompt: input.message,
+    mentionTokens,
+    workingDirectory: input.workingDirectory,
+    resolveMentionedFiles: deps.resolveMentionedFiles,
+    readReferencedFile: deps.readReferencedFile,
+  })
+
+  const withAttachments = await applyAttachmentFilesStage({
+    prompt: mentionStage.prompt,
+    files: input.files,
+  })
+  const withReferenceNotes = applyReferenceNotesStage(withAttachments, mentionStage.referenceNotes)
+  const prompt = applyWorkspaceContextStage(withReferenceNotes, workspaceSnapshot)
+
+  return {
+    prompt,
+    mentionTokens,
+    workspaceSnapshot,
+    resolvedMentionCount: mentionStage.resolvedMentionCount,
+    unresolvedMentionCount: mentionStage.unresolvedMentionCount,
+  }
+}

--- a/tests/smoke/chat-prompt-pipeline.spec.ts
+++ b/tests/smoke/chat-prompt-pipeline.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test } from '@playwright/test'
+import type { WorkspaceContextSnapshot } from '../../src/renderer/types'
+import {
+  applyAttachmentFilesStage,
+  applyMentionReferencesStage,
+  loadWorkspaceSnapshotStage,
+  parseSlashCommandInput,
+  prepareChatPrompt,
+  resolveMentionTokens,
+} from '../../src/renderer/components/chat/chatPromptPipeline'
+
+function createTextFile(name: string, content: string): File {
+  if (typeof File !== 'undefined') {
+    return new File([content], name, { type: 'text/plain' })
+  }
+  return {
+    name,
+    text: async () => content,
+  } as File
+}
+
+function createSnapshot(overrides: Partial<WorkspaceContextSnapshot> = {}): WorkspaceContextSnapshot {
+  return {
+    directory: '/tmp/workspace',
+    generatedAt: 123,
+    gitBranch: 'main',
+    gitDirtyFiles: 2,
+    topLevelDirectories: ['src'],
+    topLevelFiles: ['README.md'],
+    keyFiles: ['README.md'],
+    npmScripts: ['build'],
+    techHints: ['typescript'],
+    readmeSnippet: 'Project summary',
+    ...overrides,
+  }
+}
+
+test('parseSlashCommandInput parses command name and args while ignoring // comments', () => {
+  expect(parseSlashCommandInput('/plan alpha beta')).toEqual({
+    name: 'plan',
+    argsRaw: 'alpha beta',
+    args: ['alpha', 'beta'],
+  })
+  expect(parseSlashCommandInput('//not-a-command')).toBeNull()
+})
+
+test('applyMentionReferencesStage appends referenced content and unresolved notes', async () => {
+  const stage = await applyMentionReferencesStage({
+    prompt: 'Please inspect @README',
+    mentionTokens: ['README', 'missing-file'],
+    workingDirectory: '/tmp/workspace',
+    resolveMentionedFiles: async () => ({
+      resolved: [{ mention: 'readme', path: '/tmp/workspace/README.md', relPath: 'README.md' }],
+      unresolved: ['missing-file'],
+    }),
+    readReferencedFile: async () => ({ content: 'line\0two', truncated: true }),
+  })
+
+  expect(stage.prompt).toContain('Referenced files via @:')
+  expect(stage.prompt).toContain('--- Referenced file: README.md ---')
+  expect(stage.prompt).toContain('linetwo')
+  expect(stage.referenceNotes).toContain('README.md (truncated to 2MB preview)')
+  expect(stage.referenceNotes.some((note) => note.includes('Unresolved @ references: @missing-file'))).toBe(true)
+  expect(stage.resolvedMentionCount).toBe(1)
+  expect(stage.unresolvedMentionCount).toBe(1)
+})
+
+test('applyAttachmentFilesStage appends text and binary attachment context', async () => {
+  const prompt = await applyAttachmentFilesStage({
+    prompt: 'Base prompt',
+    files: [
+      createTextFile('notes.txt', 'hello world'),
+      createTextFile('image.png', 'not-used'),
+    ],
+  })
+
+  expect(prompt).toContain('Attached files:')
+  expect(prompt).toContain('--- File: notes.txt ---')
+  expect(prompt).toContain('hello world')
+  expect(prompt).toContain('[Attached binary files: image.png')
+})
+
+test('prepareChatPrompt runs staged pipeline and injects workspace context', async () => {
+  const snapshot = createSnapshot({ gitBranch: 'feature/pipeline' })
+  const prepared = await prepareChatPrompt(
+    {
+      message: 'Need context for @README',
+      mentions: undefined,
+      files: [createTextFile('note.md', 'draft')],
+      workingDirectory: '/tmp/workspace',
+    },
+    {
+      getWorkspaceSnapshot: async () => snapshot,
+      upsertWorkspaceSnapshot: () => {},
+      resolveMentionedFiles: async (_rootDir, mentions) => ({
+        resolved: mentions.includes('README')
+          ? [{ mention: 'readme', path: '/tmp/workspace/README.md', relPath: 'README.md' }]
+          : [],
+        unresolved: [],
+      }),
+      readReferencedFile: async () => ({ content: 'readme body', truncated: false }),
+    }
+  )
+
+  expect(resolveMentionTokens('Need context for @README')).toEqual(['README'])
+  expect(prepared.prompt).toContain('Referenced files via @:')
+  expect(prepared.prompt).toContain('Attached files:')
+  expect(prepared.prompt).toContain('[Workspace context snapshot]')
+  expect(prepared.prompt).toContain('git_branch: feature/pipeline')
+  expect(prepared.mentionTokens).toEqual(['README'])
+})
+
+test('loadWorkspaceSnapshotStage swallows snapshot errors and reports them via callback', async () => {
+  let capturedError: string | null = null
+  const snapshot = await loadWorkspaceSnapshotStage('/tmp/workspace', {
+    getWorkspaceSnapshot: async () => {
+      throw new Error('snapshot failed')
+    },
+    upsertWorkspaceSnapshot: () => {
+      throw new Error('should not be called')
+    },
+    onWorkspaceSnapshotError: (error) => {
+      capturedError = error instanceof Error ? error.message : String(error)
+    },
+  })
+
+  expect(snapshot).toBeNull()
+  expect(capturedError).toBe('snapshot failed')
+})


### PR DESCRIPTION
## Summary
- extract ChatPanel send flow into dedicated orchestration callbacks for directory resolution, slash-command handling, and Claude prompt execution
- introduce `chatPromptPipeline.ts` with staged prompt preparation for mentions, attached files, workspace snapshot enrichment, and context assembly
- add smoke coverage for staged pipeline behavior (`parseSlashCommandInput`, mention stage, attachment stage, snapshot stage, and end-to-end prompt preparation)

## Testing
- pnpm run lint:desktop
- pnpm run typecheck
- pnpm exec playwright test -c playwright.smoke.config.ts --workers=1

Closes #94

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core chat send/prompt-building logic and refactors side-effect ordering; behavior should be equivalent but regressions could affect prompt contents, plugin hooks, or directory selection flow.
> 
> **Overview**
> Refactors `ChatPanel`’s send flow into smaller orchestration callbacks: resolving/choosing the working directory, handling slash commands, ensuring a chat agent exists for a run, and sending a prepared prompt to Claude.
> 
> Introduces `chatPromptPipeline.ts`, a staged prompt builder that centralizes slash-command parsing, `@`-mention extraction + file resolution (via injected search), attachment inlining with binary-file handling, workspace snapshot loading (error-tolerant), and final prompt assembly.
> 
> Adds Playwright smoke tests covering command parsing, mention/attachment stages, snapshot error handling, and end-to-end prompt preparation output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8222e7f9f54df447593b79ec27cd9c29fdeda43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->