### PR TITLE
refactor: centralize panel registry for menu hotkey and preload

### DIFF
--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -4,6 +4,11 @@ import path from 'path'
 import os from 'os'
 import type { AppSettings } from '../renderer/types'
 import { writeFileAtomicSync } from './atomic-write'
+import {
+  PANEL_MENU_LABELS,
+  PANEL_SHORTCUT_ORDER,
+  panelFocusChannel,
+} from '../shared/panel-registry'
 
 const DEFAULT_LOCAL_DEV_DIRECTORY = path.join(os.homedir(), 'dev')
 
@@ -232,19 +237,16 @@ export function createApplicationMenu(mainWindow: BrowserWindow): void {
     }
   }
 
-  /** Panel focus items (Cmd/Ctrl+1 through 8) */
+  /** Panel focus items (Cmd/Ctrl+1 through N) */
   const panelItems: Electron.MenuItemConstructorOptions[] = [
-    { label: 'Chat', accelerator: `${mod}+1`, click: () => send('menu:focusPanel:chat') },
-    { label: 'Terminal', accelerator: `${mod}+2`, click: () => send('menu:focusPanel:terminal') },
-    { label: 'Tokens', accelerator: `${mod}+3`, click: () => send('menu:focusPanel:tokens') },
-    { label: 'Office', accelerator: `${mod}+4`, click: () => send('menu:focusPanel:scene3d') },
-    { label: 'Activity', accelerator: `${mod}+5`, click: () => send('menu:focusPanel:activity') },
-    { label: 'Memory Graph', accelerator: `${mod}+6`, click: () => send('menu:focusPanel:memoryGraph') },
-    { label: 'Agents', accelerator: `${mod}+7`, click: () => send('menu:focusPanel:agents') },
-    { label: 'Recent', accelerator: `${mod}+8`, click: () => send('menu:focusPanel:recentMemories') },
+    ...PANEL_SHORTCUT_ORDER.map((panelId, index) => ({
+      label: PANEL_MENU_LABELS[panelId],
+      accelerator: `${mod}+${index + 1}`,
+      click: () => send(panelFocusChannel(panelId)),
+    })),
     { type: 'separator' },
-    { label: 'Search Files', accelerator: `${mod}+P`, click: () => send('menu:focusPanel:fileSearch') },
-    { label: 'File Explorer', accelerator: `${mod}+Shift+E`, click: () => send('menu:focusPanel:fileExplorer') },
+    { label: 'Search Files', accelerator: `${mod}+P`, click: () => send(panelFocusChannel('fileSearch')) },
+    { label: 'File Explorer', accelerator: `${mod}+Shift+E`, click: () => send(panelFocusChannel('fileExplorer')) },
   ]
 
   const template: Electron.MenuItemConstructorOptions[] = isMac

--- a/src/renderer/components/workspace/WorkspaceMenuBar.tsx
+++ b/src/renderer/components/workspace/WorkspaceMenuBar.tsx
@@ -4,15 +4,13 @@ import { useAgentStore } from '../../store/agents'
 import { useSettingsStore } from '../../store/settings'
 import { useWorkspaceStore } from '../../store/workspace'
 import {
+  PANEL_SHORTCUTS,
   SHORTCUTS,
   PANEL_SHORTCUT_ORDER,
-  formatShortcut,
 } from '../../hooks/useHotkeys'
 
 const PANEL_SHORTCUT_LABELS: Partial<Record<PanelId, string>> = {
-  ...Object.fromEntries(
-    PANEL_SHORTCUT_ORDER.map((id, idx) => [id, formatShortcut({ key: String(idx + 1), metaOrCtrl: true })])
-  ),
+  ...Object.fromEntries(PANEL_SHORTCUT_ORDER.map((id) => [id, PANEL_SHORTCUTS[id].label])),
   fileSearch: SHORTCUTS.fileSearch.label,
   fileExplorer: SHORTCUTS.fileExplorer.label,
 }

--- a/src/renderer/components/workspace/layout-engine.ts
+++ b/src/renderer/components/workspace/layout-engine.ts
@@ -1,16 +1,10 @@
-// ── Panel Types ───────────────────────────────────────────────────
+import {
+  type PanelId,
+  ALL_PANELS,
+  PANEL_LABELS,
+} from '../../../shared/panel-registry'
 
-export type PanelId =
-  | 'chat'
-  | 'terminal'
-  | 'tokens'
-  | 'scene3d'
-  | 'activity'
-  | 'agents'
-  | 'recentMemories'
-  | 'fileExplorer'
-  | 'fileSearch'
-  | 'filePreview'
+export type { PanelId } from '../../../shared/panel-registry'
 
 /** A slot is either a single panel or a tabbed stack of panels */
 export type PanelSlot = PanelId | PanelId[]
@@ -30,24 +24,7 @@ export type Layout = LayoutColumn[]
 
 // ── Constants ─────────────────────────────────────────────────────
 
-export const ALL_PANELS: PanelId[] = [
-  'chat', 'terminal', 'tokens',
-  'scene3d', 'activity', 'agents', 'recentMemories',
-  'fileExplorer', 'fileSearch', 'filePreview',
-]
-
-export const PANEL_LABELS: Record<PanelId, string> = {
-  chat: 'CHAT',
-  terminal: 'TERMINAL',
-  tokens: 'TOKENS',
-  scene3d: 'OFFICE',
-  activity: 'ACTIVITY',
-  agents: 'AGENTS',
-  recentMemories: 'RECENT',
-  fileExplorer: 'EXPLORER',
-  fileSearch: 'SEARCH',
-  filePreview: 'EDITOR',
-}
+export { ALL_PANELS, PANEL_LABELS }
 
 export const PANEL_MIN_HEIGHT = 60
 

--- a/src/renderer/components/workspace/useWorkspaceLayoutController.ts
+++ b/src/renderer/components/workspace/useWorkspaceLayoutController.ts
@@ -3,7 +3,6 @@ import {
   type DropZone,
   type Layout,
   type PanelId,
-  ALL_PANELS,
   PANEL_MIN_HEIGHT,
   DEFAULT_LAYOUT,
   getDropZone,
@@ -13,10 +12,12 @@ import {
   clampDropZone,
   findAllPanelsInLayout,
 } from './layout-engine'
+import { isPanelId } from '../../../shared/panel-registry'
 import { useAgentStore } from '../../store/agents'
 import { useSettingsStore } from '../../store/settings'
 import { useWorkspaceStore } from '../../store/workspace'
 import {
+  PANEL_SHORTCUTS,
   useHotkeys,
   type HotkeyBinding,
   SHORTCUTS,
@@ -27,10 +28,6 @@ const WORKSPACE_LAYOUT_STATE_KEY = 'agent-observer:workspaceLayoutState'
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
-}
-
-function isPanelId(value: unknown): value is PanelId {
-  return typeof value === 'string' && ALL_PANELS.includes(value as PanelId)
 }
 
 function normalizePanelSlot(value: unknown): PanelId | PanelId[] | null {
@@ -467,17 +464,13 @@ export function useWorkspaceLayoutController(): WorkspaceLayoutController {
   }, [focusPanel])
 
   const hotkeyBindings: HotkeyBinding[] = [
-    ...PANEL_SHORTCUT_ORDER.map((panelId, index) => {
-      const shortcutKey = `focus${panelId.charAt(0).toUpperCase() + panelId.slice(1)}` as keyof typeof SHORTCUTS
-      const def = SHORTCUTS[shortcutKey] ?? {
-        hotkey: { key: String(index + 1), metaOrCtrl: true },
-        label: `⌘${index + 1}`,
-      }
+    ...PANEL_SHORTCUT_ORDER.map((panelId) => {
+      const def = PANEL_SHORTCUTS[panelId]
       return {
         hotkey: def.hotkey,
         label: def.label,
         description: def.description,
-        handler: () => focusPanel(panelId as PanelId),
+        handler: () => focusPanel(panelId),
       }
     }),
     {
@@ -571,8 +564,8 @@ export function useWorkspaceLayoutController(): WorkspaceLayoutController {
     }
 
     if (api.onFocusPanel) {
-      unsubs.push(api.onFocusPanel((panelId: string) => {
-        focusPanel(panelId as PanelId)
+      unsubs.push(api.onFocusPanel((panelId) => {
+        focusPanel(panelId)
       }))
     }
 

--- a/src/renderer/hooks/useHotkeys.ts
+++ b/src/renderer/hooks/useHotkeys.ts
@@ -1,4 +1,9 @@
 import { useEffect, useRef } from 'react'
+import {
+  type PanelId,
+  PANEL_MENU_LABELS,
+  PANEL_SHORTCUT_ORDER as PANEL_SHORTCUT_ORDER_FROM_REGISTRY,
+} from '../../shared/panel-registry'
 
 /**
  * Keyboard shortcut descriptor.
@@ -108,18 +113,40 @@ export function formatShortcut(hk: Hotkey): string {
   return parts.join('')
 }
 
+function buildPanelShortcut(panelId: PanelId, index: number) {
+  const key = String(index + 1)
+  return {
+    hotkey: { key, metaOrCtrl: true },
+    label: `${MOD}${key}`,
+    description: `Focus ${PANEL_MENU_LABELS[panelId]}`,
+  }
+}
+
+export const PANEL_SHORTCUT_ORDER = [...PANEL_SHORTCUT_ORDER_FROM_REGISTRY]
+
+export const PANEL_SHORTCUTS: Record<PanelId, {
+  hotkey: Hotkey
+  label: string
+  description: string
+}> = Object.fromEntries(
+  PANEL_SHORTCUT_ORDER.map((panelId, index) => [panelId, buildPanelShortcut(panelId, index)])
+) as Record<PanelId, {
+  hotkey: Hotkey
+  label: string
+  description: string
+}>
+
 // ── Pre-built shortcut definitions ─────────────────────────────────
 
 export const SHORTCUTS = {
   // Panel switching (Cmd+1–8)
-  focusChat:        { hotkey: { key: '1', metaOrCtrl: true }, label: `${MOD}1`, description: 'Focus Chat' },
-  focusTerminal:    { hotkey: { key: '2', metaOrCtrl: true }, label: `${MOD}2`, description: 'Focus Terminal' },
-  focusTokens:      { hotkey: { key: '3', metaOrCtrl: true }, label: `${MOD}3`, description: 'Focus Tokens' },
-  focusOffice:      { hotkey: { key: '4', metaOrCtrl: true }, label: `${MOD}4`, description: 'Focus Office' },
-  focusActivity:    { hotkey: { key: '5', metaOrCtrl: true }, label: `${MOD}5`, description: 'Focus Activity' },
-  focusMemoryGraph: { hotkey: { key: '6', metaOrCtrl: true }, label: `${MOD}6`, description: 'Focus Memory Graph' },
-  focusAgents:      { hotkey: { key: '7', metaOrCtrl: true }, label: `${MOD}7`, description: 'Focus Agents' },
-  focusRecent:      { hotkey: { key: '8', metaOrCtrl: true }, label: `${MOD}8`, description: 'Focus Recent' },
+  focusChat:        PANEL_SHORTCUTS.chat,
+  focusTerminal:    PANEL_SHORTCUTS.terminal,
+  focusTokens:      PANEL_SHORTCUTS.tokens,
+  focusOffice:      PANEL_SHORTCUTS.scene3d,
+  focusActivity:    PANEL_SHORTCUTS.activity,
+  focusAgents:      PANEL_SHORTCUTS.agents,
+  focusRecent:      PANEL_SHORTCUTS.recentMemories,
 
   // Actions
   newTerminal:      { hotkey: { key: 'n', metaOrCtrl: true, shift: true }, label: `${MOD}${SHIFT}N`, description: 'New Terminal' },
@@ -135,9 +162,3 @@ export const SHORTCUTS = {
   fileExplorer:     { hotkey: { key: 'e', metaOrCtrl: true, shift: true }, label: `${MOD}${SHIFT}E`, description: 'File Explorer' },
   escape:           { hotkey: { key: 'Escape' }, label: 'Esc', description: 'Close Menus / Deselect' },
 } as const
-
-/** Ordered panel IDs — index maps to Cmd+1 through Cmd+7 */
-export const PANEL_SHORTCUT_ORDER = [
-  'chat', 'terminal', 'tokens', 'scene3d',
-  'activity', 'agents', 'recentMemories',
-] as const

--- a/src/shared/electron-api.ts
+++ b/src/shared/electron-api.ts
@@ -8,6 +8,7 @@ import type {
   TodoRunnerJob,
   TodoRunnerJobInput,
 } from '../renderer/types'
+import type { PanelId } from './panel-registry'
 
 export type Unsubscribe = () => void
 
@@ -101,7 +102,7 @@ export interface ElectronAPI {
     onNewTerminal: (callback: () => void) => Unsubscribe
     onFocusChat: (callback: () => void) => Unsubscribe
     onResetLayout: (callback: () => void) => Unsubscribe
-    onFocusPanel: (callback: (panelId: string) => void) => Unsubscribe
+    onFocusPanel: (callback: (panelId: PanelId) => void) => Unsubscribe
   }
   fs: {
     readDir: (dirPath: string, showHidden?: boolean) => Promise<FsEntry[]>

--- a/src/shared/panel-registry.ts
+++ b/src/shared/panel-registry.ts
@@ -1,0 +1,66 @@
+export interface PanelRegistryEntry {
+  id: PanelId
+  label: string
+  menuLabel: string
+  focusShortcutOrder?: number
+}
+
+export type PanelId =
+  | 'chat'
+  | 'terminal'
+  | 'tokens'
+  | 'scene3d'
+  | 'activity'
+  | 'agents'
+  | 'recentMemories'
+  | 'fileExplorer'
+  | 'fileSearch'
+  | 'filePreview'
+
+export const PANEL_REGISTRY: readonly PanelRegistryEntry[] = [
+  { id: 'chat', label: 'CHAT', menuLabel: 'Chat', focusShortcutOrder: 1 },
+  { id: 'terminal', label: 'TERMINAL', menuLabel: 'Terminal', focusShortcutOrder: 2 },
+  { id: 'tokens', label: 'TOKENS', menuLabel: 'Tokens', focusShortcutOrder: 3 },
+  { id: 'scene3d', label: 'OFFICE', menuLabel: 'Office', focusShortcutOrder: 4 },
+  { id: 'activity', label: 'ACTIVITY', menuLabel: 'Activity', focusShortcutOrder: 5 },
+  { id: 'agents', label: 'AGENTS', menuLabel: 'Agents', focusShortcutOrder: 6 },
+  { id: 'recentMemories', label: 'RECENT', menuLabel: 'Recent', focusShortcutOrder: 7 },
+  { id: 'fileExplorer', label: 'EXPLORER', menuLabel: 'File Explorer' },
+  { id: 'fileSearch', label: 'SEARCH', menuLabel: 'Search Files' },
+  { id: 'filePreview', label: 'EDITOR', menuLabel: 'Editor' },
+]
+
+export const ALL_PANELS: PanelId[] = PANEL_REGISTRY.map((panel) => panel.id)
+
+export const PANEL_LABELS: Record<PanelId, string> = Object.fromEntries(
+  PANEL_REGISTRY.map((panel) => [panel.id, panel.label])
+) as Record<PanelId, string>
+
+export const PANEL_MENU_LABELS: Record<PanelId, string> = Object.fromEntries(
+  PANEL_REGISTRY.map((panel) => [panel.id, panel.menuLabel])
+) as Record<PanelId, string>
+
+export const PANEL_SHORTCUT_ORDER: PanelId[] = PANEL_REGISTRY
+  .filter((panel) => typeof panel.focusShortcutOrder === 'number')
+  .sort((a, b) => (a.focusShortcutOrder ?? 999) - (b.focusShortcutOrder ?? 999))
+  .map((panel) => panel.id)
+
+export type PanelFocusChannel = `menu:focusPanel:${PanelId}`
+
+export const PANEL_FOCUS_CHANNELS: PanelFocusChannel[] = ALL_PANELS
+  .map((panelId) => `menu:focusPanel:${panelId}` as PanelFocusChannel)
+
+const PANEL_SET = new Set<PanelId>(ALL_PANELS)
+
+export function isPanelId(value: unknown): value is PanelId {
+  return typeof value === 'string' && PANEL_SET.has(value as PanelId)
+}
+
+export function panelFocusChannel(panelId: PanelId): PanelFocusChannel {
+  return `menu:focusPanel:${panelId}`
+}
+
+export function panelIdFromFocusChannel(channel: string): PanelId | null {
+  const panelId = channel.split(':').pop() ?? ''
+  return isPanelId(panelId) ? panelId : null
+}

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -12,5 +12,5 @@
     "forceConsistentCasingInFileNames": true,
     "composite": true
   },
-  "include": ["src/renderer/**/*"]
+  "include": ["src/renderer/**/*", "src/shared/**/*"]
 }


### PR DESCRIPTION
## Summary
- add a shared canonical panel registry (`src/shared/panel-registry.ts`) containing panel ids, labels, menu labels, shortcut order, and focus menu channel helpers
- rewire renderer workspace types/labels and hotkey focus mappings to derive from the shared registry
- derive main-process focus menu items and preload focus channel listeners from the same registry, removing hard-coded channel lists and eliminating the invalid `memoryGraph` target
- tighten `ElectronAPI.settings.onFocusPanel` typing to `PanelId` and include shared types in `tsconfig.web.json`

## Testing
- pnpm run lint:desktop
- pnpm run typecheck
- pnpm exec playwright test -c playwright.smoke.config.ts --workers=1

Closes #96

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches panel focus routing across main/preload/renderer; behavior depends on the registry being complete/correct, so mistakes could break keyboard shortcuts or menu-driven focus changes.
> 
> **Overview**
> Introduces a shared `panel-registry` that becomes the single source of truth for `PanelId`s, UI/menu labels, focus shortcut ordering, and `menu:focusPanel:*` channel helpers.
> 
> Refactors the Electron app menu, preload `onFocusPanel` wiring, and renderer workspace layout/hotkey/menu-bar code to generate focus items/listeners/labels from the registry instead of hard-coded lists, and tightens `ElectronAPI.settings.onFocusPanel` to accept a typed `PanelId`.
> 
> Updates `tsconfig.web.json` to include `src/shared/**/*` so renderer builds/typechecks shared registry types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6cfdfac90f894ab123840ed4bee7ce46ed7890d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->