### PR TITLE
Refactor plugin runtime into modular discovery/loader/registry components

### DIFF
--- a/src/renderer/plugins/runtime.ts
+++ b/src/renderer/plugins/runtime.ts
@@ -1,534 +1,57 @@
 import type {
-  ClaudeProfilesConfig,
   PluginHookEvent,
   PluginHookEventPayloadMap,
   PluginHookHandler,
 } from '../types'
 import { logRendererEvent } from '../lib/diagnostics'
 import { registerDiagnosticsHooks } from './builtins/diagnosticsHooks'
+import { createPluginCatalogStore } from './runtime/catalog-store'
+import type {
+  PluginCatalogSnapshot,
+  PluginCommandContext,
+  PluginCommandDefinition,
+  PluginCommandExecutionResult,
+  PluginCommandSummary,
+  PluginPromptTransformApplyResult,
+  PluginPromptTransformContext,
+  PluginPromptTransformerDefinition,
+} from './runtime/contracts'
+import {
+  collectPluginDirsFromProfiles as collectPluginDirsFromProfilesImpl,
+  discoverPlugins,
+} from './runtime/discovery'
+import { toErrorMessage } from './runtime/helpers'
+import { createPluginLoader } from './runtime/loader'
+import { createPluginRegistries } from './runtime/registries'
 
-interface RegisteredHook<E extends PluginHookEvent = PluginHookEvent> {
-  id: string
-  event: E
-  pluginId: string
-  order: number
-  handler: PluginHookHandler<E>
-}
+export type {
+  PluginCatalogSnapshot,
+  PluginCommandContext,
+  PluginCommandDefinition,
+  PluginCommandExecutionResult,
+  PluginCommandSummary,
+  PluginHookDefinition,
+  PluginPromptTransformApplyResult,
+  PluginPromptTransformContext,
+  PluginPromptTransformerDefinition,
+  RuntimeDiscoveredPlugin,
+} from './runtime/contracts'
 
-interface RegisteredPluginCommand {
-  id: string
-  name: string
-  pluginId: string
-  description: string | null
-  execute: PluginCommandDefinition['execute']
-}
-
-interface RegisteredPromptTransformer {
-  id: string
-  pluginId: string
-  order: number
-  transform: PluginPromptTransformerDefinition['transform']
-}
-
-type HooksByEvent = {
-  [E in PluginHookEvent]: RegisteredHook<E>[]
-}
-
-type PluginLoadState = 'loaded' | 'failed' | 'skipped'
-
-interface RawDiscoveredPlugin {
-  id: string
-  name: string
-  version: string
-  description: string | null
-  rootDir: string
-  manifestPath: string
-  source: 'agent-observer.plugin.json' | 'openclaw.plugin.json' | 'package.json'
-  rendererEntry: string | null
-}
-
-export interface RuntimeDiscoveredPlugin extends RawDiscoveredPlugin {
-  loadState: PluginLoadState
-  loadError: string | null
-}
-
-export interface PluginCommandContext {
-  chatSessionId: string
-  workspaceDirectory: string | null
-  agentId: string | null
-  rawMessage: string
-  argsRaw: string
-  args: string[]
-  attachmentNames: string[]
-  mentionPaths: string[]
-}
-
-export interface PluginCommandDefinition {
-  name: string
-  description?: string
-  execute: (
-    context: PluginCommandContext
-  ) =>
-    | void
-    | string
-    | { message?: string; isError?: boolean; error?: string }
-    | Promise<void | string | { message?: string; isError?: boolean; error?: string }>
-}
-
-export interface PluginCommandSummary {
-  name: string
-  pluginId: string
-  description: string | null
-}
-
-export interface PluginCommandExecutionResult {
-  handled: boolean
-  commandName: string
-  pluginId: string | null
-  message: string | null
-  isError: boolean
-}
-
-export interface PluginPromptTransformContext {
-  chatSessionId: string
-  workspaceDirectory: string | null
-  agentId: string | null
-  rawMessage: string
-  prompt: string
-  mentionCount: number
-  attachmentCount: number
-}
-
-export interface PluginPromptTransformerDefinition {
-  transform: (
-    context: PluginPromptTransformContext
-  ) =>
-    | void
-    | string
-    | { prompt?: string; cancel?: boolean; error?: string }
-    | Promise<void | string | { prompt?: string; cancel?: boolean; error?: string }>
-}
-
-export interface PluginPromptTransformApplyResult {
-  prompt: string
-  transformed: boolean
-  canceled: boolean
-  errorMessage: string | null
-}
-
-export interface PluginHookDefinition<E extends PluginHookEvent = PluginHookEvent> {
-  event: E
-  handler: PluginHookHandler<E>
-  order?: number
-}
-
-export interface PluginCatalogSnapshot {
-  directories: string[]
-  plugins: RuntimeDiscoveredPlugin[]
-  commands: PluginCommandSummary[]
-  warnings: string[]
-  syncedAt: number
-}
-
-interface LoadedPluginInstance {
-  entryPath: string
-  dispose: () => void
-}
-
-interface PluginModule {
-  default?: unknown
-  register?: unknown
-}
-
-interface RendererPluginApi {
-  registerHook: <E extends PluginHookEvent>(
-    event: E | PluginHookDefinition<E>,
-    handler?: PluginHookHandler<E>,
-    options?: { order?: number }
-  ) => () => void
-  on: <E extends PluginHookEvent>(
-    event: E,
-    handler: PluginHookHandler<E>,
-    options?: { order?: number }
-  ) => () => void
-  registerCommand: (
-    command: PluginCommandDefinition
-  ) => () => void
-  registerPromptTransformer: (
-    transformer: PluginPromptTransformerDefinition,
-    options?: { order?: number }
-  ) => () => void
-  log: (level: 'info' | 'warn' | 'error', event: string, payload?: Record<string, unknown>) => void
-  plugin: RawDiscoveredPlugin
-}
-
-type RegisterPluginFunction = (api: RendererPluginApi) => unknown | Promise<unknown>
-
-const hooksByEvent: HooksByEvent = {
-  before_agent_start: [],
-  agent_end: [],
-  session_start: [],
-  session_end: [],
-  message_received: [],
-  message_sending: [],
-  message_sent: [],
-  before_tool_call: [],
-  after_tool_call: [],
-  tool_result_persist: [],
-}
-
-function isPluginHookEvent(value: string): value is PluginHookEvent {
-  return Object.prototype.hasOwnProperty.call(hooksByEvent, value)
-}
-
-const pluginCatalogListeners = new Set<() => void>()
-const loadedPluginInstances = new Map<string, LoadedPluginInstance>()
-const pluginLoadErrors = new Map<string, string>()
-const pluginCommandsByName = new Map<string, RegisteredPluginCommand>()
-const promptTransformers: RegisteredPromptTransformer[] = []
-const IGNORED_CHILD_DIRS = new Set([
-  'node_modules',
-  '.git',
-  '.next',
-  'dist',
-  'build',
-  'out',
-  '.turbo',
-  '.pnpm-store',
-  '.yarn',
-  '.cache',
-])
-
-let hookCounter = 0
-let commandCounter = 0
-let promptTransformerCounter = 0
-let runtimeInitialized = false
-let lastCatalogSignature = ''
-let pluginCatalogSnapshot: PluginCatalogSnapshot = {
-  directories: [],
-  plugins: [],
-  commands: [],
-  warnings: [],
-  syncedAt: 0,
-}
-
-function getHooksForEvent<E extends PluginHookEvent>(event: E): RegisteredHook<E>[] {
-  return hooksByEvent[event]
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  if (typeof value !== 'object' || value === null) return null
-  return value as Record<string, unknown>
-}
-
-function asString(value: unknown): string | null {
-  if (typeof value !== 'string') return null
-  const trimmed = value.trim()
-  return trimmed ? trimmed : null
-}
-
-function asStringArray(value: unknown): string[] {
-  if (!Array.isArray(value)) return []
-  return value
-    .map((entry) => asString(entry))
-    .filter((entry): entry is string => Boolean(entry))
-}
-
-function asFiniteNumber(value: unknown): number | null {
-  if (typeof value !== 'number' || !Number.isFinite(value)) return null
-  return value
-}
-
-function dedupePreserveOrder(values: string[]): string[] {
-  const seen = new Set<string>()
-  const next: string[] = []
-  for (const value of values) {
-    const trimmed = value.trim()
-    if (!trimmed || seen.has(trimmed)) continue
-    seen.add(trimmed)
-    next.push(trimmed)
-  }
-  return next
-}
-
-function getPathBaseName(targetPath: string): string {
-  const normalized = targetPath.replace(/\\/g, '/').replace(/\/+$/, '')
-  const parts = normalized.split('/').filter(Boolean)
-  return parts[parts.length - 1] ?? targetPath
-}
-
-function joinPath(base: string, name: string): string {
-  if (base.endsWith('/') || base.endsWith('\\')) return `${base}${name}`
-  return `${base}/${name}`
-}
-
-function isAbsolutePath(input: string): boolean {
-  return input.startsWith('/')
-    || /^[a-zA-Z]:[\\/]/.test(input)
-    || input.startsWith('\\\\')
-}
-
-function replaceTildePrefix(rawPath: string, homeDir: string): string {
-  if (rawPath === '~') return homeDir
-  if (rawPath.startsWith('~/') || rawPath.startsWith('~\\')) {
-    return `${homeDir}${rawPath.slice(1)}`
-  }
-  return rawPath
-}
-
-function toFileModuleSpecifier(filePath: string, versionTag?: number): string {
-  const normalized = filePath.replace(/\\/g, '/')
-  const base = /^[a-zA-Z]:\//.test(normalized)
-    ? `file:///${normalized}`
-    : `file://${normalized}`
-  const encoded = encodeURI(base)
-  if (!versionTag || !Number.isFinite(versionTag)) return encoded
-  return `${encoded}?v=${Math.floor(versionTag)}`
-}
-
-function toErrorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err)
-}
-
-function runDisposer(
-  disposer: (() => void) | null | undefined,
-  context: string,
-  pluginId?: string
-): void {
-  if (!disposer) return
-  try {
-    disposer()
-  } catch (err) {
-    logRendererEvent('warn', 'plugin.runtime.dispose_failed', {
-      context,
-      pluginId,
-      error: toErrorMessage(err),
-    })
-  }
-}
-
-function normalizeCommandName(rawName: string): string | null {
-  const trimmed = rawName.trim()
-  if (!trimmed) return null
-  const withoutPrefix = trimmed.startsWith('/') ? trimmed.slice(1) : trimmed
-  const normalized = withoutPrefix.trim().toLowerCase()
-  if (!normalized) return null
-  if (!/^[a-z0-9._-]+$/.test(normalized)) return null
-  return normalized
-}
-
-function updatePluginCatalogSnapshot(next: PluginCatalogSnapshot): void {
-  pluginCatalogSnapshot = next
-  for (const listener of pluginCatalogListeners) {
-    try {
-      listener()
-    } catch (err) {
-      console.error('[plugins] listener failure:', err)
-    }
-  }
-}
+const catalogStore = createPluginCatalogStore()
+const registries = createPluginRegistries()
 
 function refreshSnapshotCommands(): void {
-  if (pluginCatalogSnapshot.syncedAt === 0) return
-  updatePluginCatalogSnapshot({
-    ...pluginCatalogSnapshot,
-    commands: getRegisteredPluginCommands(),
-    syncedAt: Date.now(),
-  })
-}
-
-function normalizeCommandExecutionOutput(
-  output: unknown
-): { message: string | null; isError: boolean } {
-  if (output === null || output === undefined) {
-    return { message: null, isError: false }
-  }
-  if (typeof output === 'string') {
-    const message = output.trim()
-    return { message: message || null, isError: false }
-  }
-  const record = asRecord(output)
-  if (record) {
-    const messageFromMessage = asString(record.message)
-    const messageFromError = asString(record.error)
-    const isError = record.isError === true || Boolean(messageFromError)
-    if (messageFromMessage) {
-      return { message: messageFromMessage, isError }
-    }
-    if (messageFromError) {
-      return { message: messageFromError, isError: true }
-    }
-  }
-  try {
-    return { message: JSON.stringify(output), isError: false }
-  } catch {
-    return { message: String(output), isError: false }
-  }
-}
-
-function normalizePromptTransformOutput(
-  output: unknown
-): { nextPrompt: string | null; cancel: boolean; errorMessage: string | null } {
-  if (output === null || output === undefined) {
-    return { nextPrompt: null, cancel: false, errorMessage: null }
-  }
-  if (typeof output === 'string') {
-    return { nextPrompt: output, cancel: false, errorMessage: null }
-  }
-  const record = asRecord(output)
-  if (!record) {
-    return { nextPrompt: null, cancel: false, errorMessage: null }
-  }
-  return {
-    nextPrompt: asString(record.prompt),
-    cancel: record.cancel === true,
-    errorMessage: asString(record.error),
-  }
-}
-
-async function readJsonFile(filePath: string): Promise<Record<string, unknown> | null> {
-  try {
-    const file = await window.electronAPI.fs.readFile(filePath)
-    const parsed = JSON.parse(file.content) as unknown
-    return asRecord(parsed)
-  } catch {
-    return null
-  }
-}
-
-function readManifestMetadata(
-  raw: Record<string, unknown>,
-  fallbackName: string
-): { id: string; name: string; version: string; description: string | null; rendererEntry: string | null } {
-  const name = asString(raw.name) ?? fallbackName
-  const version = asString(raw.version) ?? '0.0.0'
-  const description = asString(raw.description)
-  const rendererEntry = asString(raw.rendererEntry)
-    ?? asString(raw.entry)
-    ?? asString(raw.main)
-    ?? null
-  return {
-    id: asString(raw.id) ?? name,
-    name,
-    version,
-    description,
-    rendererEntry,
-  }
-}
-
-async function detectPluginAtRoot(rootDir: string): Promise<RawDiscoveredPlugin | null> {
-  const fallbackName = getPathBaseName(rootDir)
-
-  const agentSpaceManifestPath = joinPath(rootDir, 'agent-observer.plugin.json')
-  const agentSpaceManifest = await readJsonFile(agentSpaceManifestPath)
-  if (agentSpaceManifest) {
-    const metadata = readManifestMetadata(agentSpaceManifest, fallbackName)
-    return {
-      ...metadata,
-      rootDir,
-      manifestPath: agentSpaceManifestPath,
-      source: 'agent-observer.plugin.json',
-    }
-  }
-
-  const openClawManifestPath = joinPath(rootDir, 'openclaw.plugin.json')
-  const openClawManifest = await readJsonFile(openClawManifestPath)
-  if (openClawManifest) {
-    const metadata = readManifestMetadata(openClawManifest, fallbackName)
-    return {
-      ...metadata,
-      rootDir,
-      manifestPath: openClawManifestPath,
-      source: 'openclaw.plugin.json',
-    }
-  }
-
-  const packagePath = joinPath(rootDir, 'package.json')
-  const packageJson = await readJsonFile(packagePath)
-  if (!packageJson) return null
-
-  const openClawConfig = asRecord(packageJson.openclaw)
-  const agentSpaceConfig = asRecord(packageJson.agentSpace)
-  const extensionEntries = asStringArray(openClawConfig?.extensions)
-  const packageKeywords = asStringArray(packageJson.keywords)
-  const hasPluginKeyword = packageKeywords.some((keyword) =>
-    keyword === 'openclaw-plugin' || keyword === 'agent-observer-plugin'
-  )
-  const metadata = readManifestMetadata(packageJson, fallbackName)
-  const rendererEntryFromConfig = asString(agentSpaceConfig?.rendererEntry)
-    ?? asString(openClawConfig?.rendererEntry)
-    ?? extensionEntries[0]
-    ?? null
-
-  if (!hasPluginKeyword && extensionEntries.length === 0 && !rendererEntryFromConfig) {
-    return null
-  }
-
-  return {
-    ...metadata,
-    rendererEntry: rendererEntryFromConfig ?? metadata.rendererEntry,
-    rootDir,
-    manifestPath: packagePath,
-    source: 'package.json',
-  }
-}
-
-async function listCandidatePluginRoots(directory: string): Promise<string[]> {
-  const roots = [directory]
-  try {
-    const entries = await window.electronAPI.fs.readDir(directory)
-    for (const entry of entries) {
-      if (!entry.isDirectory) continue
-      if (entry.name.startsWith('.')) continue
-      if (IGNORED_CHILD_DIRS.has(entry.name)) continue
-      roots.push(entry.path)
-      if (roots.length >= 80) break
-    }
-  } catch {
-    // Keep root-only scan if we fail to enumerate children.
-  }
-  return roots
-}
-
-async function resolveRendererEntryPath(plugin: RawDiscoveredPlugin, homeDir: string): Promise<string | null> {
-  if (!plugin.rendererEntry) return null
-  const expanded = replaceTildePrefix(plugin.rendererEntry, homeDir)
-  return isAbsolutePath(expanded) ? expanded : joinPath(plugin.rootDir, expanded)
+  catalogStore.updateCommands(registries.getRegisteredCommands())
 }
 
 export function registerPluginCommand(
   command: PluginCommandDefinition,
   options?: { pluginId?: string }
 ): () => void {
-  const normalizedName = normalizeCommandName(command.name)
-  if (!normalizedName) {
-    throw new Error(`Invalid plugin command name: ${command.name}`)
-  }
-
-  const registered: RegisteredPluginCommand = {
-    id: `command-${++commandCounter}`,
-    name: normalizedName,
-    pluginId: options?.pluginId ?? 'anonymous',
-    description: asString(command.description) ?? null,
-    execute: command.execute,
-  }
-
-  const existing = pluginCommandsByName.get(normalizedName)
-  if (existing && existing.id !== registered.id) {
-    logRendererEvent('warn', 'plugin.command.replaced', {
-      commandName: normalizedName,
-      replacedPluginId: existing.pluginId,
-      pluginId: registered.pluginId,
-    })
-  }
-
-  pluginCommandsByName.set(normalizedName, registered)
+  const dispose = registries.registerCommand(command, options)
   refreshSnapshotCommands()
-
   return () => {
-    const current = pluginCommandsByName.get(normalizedName)
-    if (!current || current.id !== registered.id) return
-    pluginCommandsByName.delete(normalizedName)
+    dispose()
     refreshSnapshotCommands()
   }
 }
@@ -537,375 +60,16 @@ export function registerPluginPromptTransformer(
   transformer: PluginPromptTransformerDefinition,
   options?: { pluginId?: string; order?: number }
 ): () => void {
-  const entry: RegisteredPromptTransformer = {
-    id: `prompt-transformer-${++promptTransformerCounter}`,
-    pluginId: options?.pluginId ?? 'anonymous',
-    order: options?.order ?? 100,
-    transform: transformer.transform,
-  }
-  promptTransformers.push(entry)
-  promptTransformers.sort((a, b) => a.order - b.order)
-
-  return () => {
-    const index = promptTransformers.findIndex((candidate) => candidate.id === entry.id)
-    if (index >= 0) {
-      promptTransformers.splice(index, 1)
-    }
-  }
+  return registries.registerPromptTransformer(transformer, options)
 }
 
-export function getRegisteredPromptTransformerCount(): number {
-  return promptTransformers.length
-}
+const pluginLoader = createPluginLoader({
+  registerHookFromDefinition: registries.registerHookFromDefinition,
+  registerCommand: registerPluginCommand,
+  registerPromptTransformer: registerPluginPromptTransformer,
+})
 
-export function getRegisteredPluginCommands(): PluginCommandSummary[] {
-  return Array.from(pluginCommandsByName.values())
-    .map((command) => ({
-      name: command.name,
-      pluginId: command.pluginId,
-      description: command.description,
-    }))
-    .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }))
-}
-
-export async function invokePluginCommand(
-  commandName: string,
-  context: PluginCommandContext
-): Promise<PluginCommandExecutionResult> {
-  const normalizedName = normalizeCommandName(commandName)
-  if (!normalizedName) {
-    return {
-      handled: false,
-      commandName: commandName.trim(),
-      pluginId: null,
-      message: null,
-      isError: false,
-    }
-  }
-
-  const command = pluginCommandsByName.get(normalizedName)
-  if (!command) {
-    return {
-      handled: false,
-      commandName: normalizedName,
-      pluginId: null,
-      message: null,
-      isError: false,
-    }
-  }
-
-  try {
-    const output = await command.execute(context)
-    const normalizedOutput = normalizeCommandExecutionOutput(output)
-    logRendererEvent('info', 'plugin.command.executed', {
-      pluginId: command.pluginId,
-      commandName: normalizedName,
-      hasMessage: Boolean(normalizedOutput.message),
-      isError: normalizedOutput.isError,
-    })
-    return {
-      handled: true,
-      commandName: normalizedName,
-      pluginId: command.pluginId,
-      message: normalizedOutput.message,
-      isError: normalizedOutput.isError,
-    }
-  } catch (err) {
-    const errorMessage = toErrorMessage(err)
-    logRendererEvent('warn', 'plugin.command.failed', {
-      pluginId: command.pluginId,
-      commandName: normalizedName,
-      error: errorMessage,
-    })
-    return {
-      handled: true,
-      commandName: normalizedName,
-      pluginId: command.pluginId,
-      message: errorMessage,
-      isError: true,
-    }
-  }
-}
-
-export async function applyPluginPromptTransforms(
-  context: PluginPromptTransformContext
-): Promise<PluginPromptTransformApplyResult> {
-  if (promptTransformers.length === 0) {
-    return {
-      prompt: context.prompt,
-      transformed: false,
-      canceled: false,
-      errorMessage: null,
-    }
-  }
-
-  let currentPrompt = context.prompt
-  let transformed = false
-
-  for (const transformer of promptTransformers) {
-    try {
-      const output = await transformer.transform({
-        ...context,
-        prompt: currentPrompt,
-      })
-      const normalizedOutput = normalizePromptTransformOutput(output)
-      if (typeof normalizedOutput.nextPrompt === 'string') {
-        if (normalizedOutput.nextPrompt !== currentPrompt) {
-          transformed = true
-        }
-        currentPrompt = normalizedOutput.nextPrompt
-      }
-      if (normalizedOutput.cancel) {
-        return {
-          prompt: currentPrompt,
-          transformed,
-          canceled: true,
-          errorMessage: normalizedOutput.errorMessage
-            ?? `Prompt canceled by plugin ${transformer.pluginId}`,
-        }
-      }
-    } catch (err) {
-      logRendererEvent('warn', 'plugin.prompt_transform.failed', {
-        pluginId: transformer.pluginId,
-        transformerId: transformer.id,
-        error: toErrorMessage(err),
-      })
-    }
-  }
-
-  return {
-    prompt: currentPrompt,
-    transformed,
-    canceled: false,
-    errorMessage: null,
-  }
-}
-
-function normalizeHookRegistration<E extends PluginHookEvent>(
-  event: E | PluginHookDefinition<E>,
-  handler?: PluginHookHandler<E>,
-  options?: { order?: number }
-): { event: E; handler: PluginHookHandler<E>; order?: number } {
-  if (typeof event === 'string') {
-    if (typeof handler !== 'function') {
-      throw new Error(`Hook "${event}" requires a handler function`)
-    }
-    return {
-      event,
-      handler,
-      order: options?.order,
-    }
-  }
-
-  const registration = asRecord(event as unknown)
-  if (!registration) {
-    throw new Error('Hook registration must be a string event or object definition')
-  }
-
-  const rawEvent = asString(registration.event)
-  if (!rawEvent || !isPluginHookEvent(rawEvent)) {
-    throw new Error(`Unsupported hook event: ${String(registration.event)}`)
-  }
-
-  if (typeof registration.handler !== 'function') {
-    throw new Error(`Hook "${rawEvent}" requires a handler function`)
-  }
-
-  return {
-    event: rawEvent as E,
-    handler: registration.handler as PluginHookHandler<E>,
-    order: asFiniteNumber(registration.order) ?? options?.order,
-  }
-}
-
-async function loadPluginModule(
-  plugin: RawDiscoveredPlugin,
-  entryPath: string
-): Promise<LoadedPluginInstance> {
-  const stat = await window.electronAPI.fs.stat(entryPath)
-  if (!stat.isFile) {
-    throw new Error(`Renderer entry is not a file: ${entryPath}`)
-  }
-
-  const moduleSpecifier = toFileModuleSpecifier(entryPath, stat.modified)
-  const moduleExports = await import(/* @vite-ignore */ moduleSpecifier) as PluginModule
-  const registerCandidate = typeof moduleExports.default === 'function'
-    ? moduleExports.default
-    : moduleExports.register
-  if (typeof registerCandidate !== 'function') {
-    throw new Error('Plugin module must export default function register(api) or named register(api)')
-  }
-
-  const hookDisposers: Array<() => void> = []
-  const registerHookFromPlugin = <E extends PluginHookEvent>(
-    event: E | PluginHookDefinition<E>,
-    handler?: PluginHookHandler<E>,
-    options?: { order?: number }
-  ): (() => void) => {
-    const normalized = normalizeHookRegistration(event, handler, options)
-    const dispose = registerPluginHook(normalized.event, normalized.handler, {
-      pluginId: plugin.id,
-      order: normalized.order,
-    })
-    hookDisposers.push(dispose)
-    return () => {
-      const index = hookDisposers.indexOf(dispose)
-      if (index >= 0) hookDisposers.splice(index, 1)
-      runDisposer(dispose, 'hook_unregister', plugin.id)
-    }
-  }
-
-  const commandDisposers: Array<() => void> = []
-  const registerCommandFromPlugin = (command: PluginCommandDefinition): (() => void) => {
-    const dispose = registerPluginCommand(command, { pluginId: plugin.id })
-    commandDisposers.push(dispose)
-    return () => {
-      const index = commandDisposers.indexOf(dispose)
-      if (index >= 0) commandDisposers.splice(index, 1)
-      runDisposer(dispose, 'command_unregister', plugin.id)
-    }
-  }
-
-  const promptTransformDisposers: Array<() => void> = []
-  const registerPromptTransformerFromPlugin = (
-    transformer: PluginPromptTransformerDefinition,
-    options?: { order?: number }
-  ): (() => void) => {
-    const dispose = registerPluginPromptTransformer(transformer, {
-      pluginId: plugin.id,
-      order: options?.order,
-    })
-    promptTransformDisposers.push(dispose)
-    return () => {
-      const index = promptTransformDisposers.indexOf(dispose)
-      if (index >= 0) promptTransformDisposers.splice(index, 1)
-      runDisposer(dispose, 'prompt_transform_unregister', plugin.id)
-    }
-  }
-
-  const api: RendererPluginApi = {
-    registerHook: registerHookFromPlugin,
-    on: registerHookFromPlugin,
-    registerCommand: registerCommandFromPlugin,
-    registerPromptTransformer: registerPromptTransformerFromPlugin,
-    log: (level, event, payload) => {
-      logRendererEvent(level, `plugin.${plugin.id}.${event}`, payload)
-    },
-    plugin,
-  }
-
-  const pluginCleanupCandidates: Array<() => void> = []
-  const register = registerCandidate as RegisterPluginFunction
-  const registrationResult = await register(api)
-  if (typeof registrationResult === 'function') {
-    pluginCleanupCandidates.push(registrationResult as () => void)
-  } else {
-    const registrationRecord = asRecord(registrationResult)
-    const disposeMaybe = registrationRecord?.dispose
-    if (typeof disposeMaybe === 'function') {
-      pluginCleanupCandidates.push(disposeMaybe as () => void)
-    }
-  }
-
-  const dispose = () => {
-    while (pluginCleanupCandidates.length > 0) {
-      const candidate = pluginCleanupCandidates.pop()
-      runDisposer(candidate, 'plugin_unregister', plugin.id)
-    }
-    while (commandDisposers.length > 0) {
-      const commandDispose = commandDisposers.pop()
-      runDisposer(commandDispose, 'command_unregister', plugin.id)
-    }
-    while (promptTransformDisposers.length > 0) {
-      const promptTransformDispose = promptTransformDisposers.pop()
-      runDisposer(promptTransformDispose, 'prompt_transform_unregister', plugin.id)
-    }
-    while (hookDisposers.length > 0) {
-      const hookDispose = hookDisposers.pop()
-      runDisposer(hookDispose, 'hook_unregister', plugin.id)
-    }
-  }
-
-  return { entryPath, dispose }
-}
-
-async function reconcileLoadedPlugins(
-  plugins: RawDiscoveredPlugin[],
-  homeDir: string
-): Promise<void> {
-  const desiredEntryPaths = new Map<string, string | null>()
-  for (const plugin of plugins) {
-    desiredEntryPaths.set(plugin.manifestPath, await resolveRendererEntryPath(plugin, homeDir))
-  }
-
-  for (const [manifestPath, instance] of loadedPluginInstances) {
-    const desiredEntryPath = desiredEntryPaths.get(manifestPath)
-    if (!desiredEntryPath || desiredEntryPath !== instance.entryPath) {
-      runDisposer(instance.dispose, 'plugin_reload', manifestPath)
-      loadedPluginInstances.delete(manifestPath)
-    }
-  }
-
-  for (const manifestPath of Array.from(pluginLoadErrors.keys())) {
-    if (!desiredEntryPaths.has(manifestPath)) {
-      pluginLoadErrors.delete(manifestPath)
-    }
-  }
-
-  for (const plugin of plugins) {
-    const entryPath = desiredEntryPaths.get(plugin.manifestPath) ?? null
-    if (!entryPath) {
-      pluginLoadErrors.delete(plugin.manifestPath)
-      continue
-    }
-    if (loadedPluginInstances.has(plugin.manifestPath)) {
-      pluginLoadErrors.delete(plugin.manifestPath)
-      continue
-    }
-
-    try {
-      const instance = await loadPluginModule(plugin, entryPath)
-      loadedPluginInstances.set(plugin.manifestPath, instance)
-      pluginLoadErrors.delete(plugin.manifestPath)
-      logRendererEvent('info', 'plugin.runtime.loaded', {
-        pluginId: plugin.id,
-        manifestPath: plugin.manifestPath,
-        entryPath,
-      })
-    } catch (err) {
-      const message = toErrorMessage(err)
-      pluginLoadErrors.set(plugin.manifestPath, message)
-      logRendererEvent('warn', 'plugin.runtime.load_failed', {
-        pluginId: plugin.id,
-        manifestPath: plugin.manifestPath,
-        entryPath,
-        error: message,
-      })
-    }
-  }
-}
-
-function toRuntimePlugin(plugin: RawDiscoveredPlugin): RuntimeDiscoveredPlugin {
-  if (!plugin.rendererEntry) {
-    return {
-      ...plugin,
-      loadState: 'skipped',
-      loadError: null,
-    }
-  }
-  if (loadedPluginInstances.has(plugin.manifestPath)) {
-    return {
-      ...plugin,
-      loadState: 'loaded',
-      loadError: null,
-    }
-  }
-  return {
-    ...plugin,
-    loadState: 'failed',
-    loadError: pluginLoadErrors.get(plugin.manifestPath) ?? 'Renderer entry failed to load',
-  }
-}
+let runtimeInitialized = false
 
 async function syncPluginCatalogFromSettings(): Promise<PluginCatalogSnapshot | null> {
   try {
@@ -919,93 +83,71 @@ async function syncPluginCatalogFromSettings(): Promise<PluginCatalogSnapshot | 
   }
 }
 
+export function getRegisteredPromptTransformerCount(): number {
+  return registries.getPromptTransformerCount()
+}
+
+export function getRegisteredPluginCommands(): PluginCommandSummary[] {
+  return registries.getRegisteredCommands()
+}
+
+export async function invokePluginCommand(
+  commandName: string,
+  context: PluginCommandContext
+): Promise<PluginCommandExecutionResult> {
+  return registries.invokeCommand(commandName, context)
+}
+
+export async function applyPluginPromptTransforms(
+  context: PluginPromptTransformContext
+): Promise<PluginPromptTransformApplyResult> {
+  return registries.applyPromptTransforms(context)
+}
+
 export function getPluginCatalogSnapshot(): PluginCatalogSnapshot {
-  return pluginCatalogSnapshot
+  return catalogStore.getSnapshot()
 }
 
 export function subscribePluginCatalog(listener: () => void): () => void {
-  pluginCatalogListeners.add(listener)
-  return () => {
-    pluginCatalogListeners.delete(listener)
-  }
+  return catalogStore.subscribe(listener)
 }
 
-export function collectPluginDirsFromProfiles(config: ClaudeProfilesConfig | undefined): string[] {
-  if (!config) return []
-  return dedupePreserveOrder(
-    config.profiles.flatMap((profile) => profile.pluginDirs.map((path) => path.trim()))
-  )
+export function collectPluginDirsFromProfiles(config: Parameters<typeof collectPluginDirsFromProfilesImpl>[0]): string[] {
+  return collectPluginDirsFromProfilesImpl(config)
 }
 
 export async function syncPluginCatalog(pluginDirs: string[]): Promise<PluginCatalogSnapshot> {
   if (!window.electronAPI?.fs) {
-    return pluginCatalogSnapshot
+    return getPluginCatalogSnapshot()
   }
 
-  const normalizedInputDirs = dedupePreserveOrder(pluginDirs)
-  const homeDir = await window.electronAPI.fs.homeDir()
-  const normalizedDirs = dedupePreserveOrder(
-    normalizedInputDirs.map((dir) => replaceTildePrefix(dir, homeDir))
-  )
-  const nextSignature = normalizedDirs.join('::')
-  if (nextSignature === lastCatalogSignature) {
-    return pluginCatalogSnapshot
+  const discovery = await discoverPlugins(pluginDirs)
+  if (catalogStore.matchesSignature(discovery.signature)) {
+    return getPluginCatalogSnapshot()
   }
 
-  const discoveryWarnings: string[] = []
-  const pluginsByManifest = new Map<string, RawDiscoveredPlugin>()
-  const scannedDirectories: string[] = []
+  await pluginLoader.reconcileLoadedPlugins(discovery.plugins, discovery.homeDir)
 
-  for (const directory of normalizedDirs) {
-    try {
-      const stat = await window.electronAPI.fs.stat(directory)
-      if (!stat.isDirectory) {
-        discoveryWarnings.push(`Plugin dir is not a directory: ${directory}`)
-        continue
-      }
-    } catch {
-      discoveryWarnings.push(`Plugin dir not found: ${directory}`)
-      continue
-    }
-
-    scannedDirectories.push(directory)
-    const roots = await listCandidatePluginRoots(directory)
-    for (const rootDir of roots) {
-      const discovered = await detectPluginAtRoot(rootDir)
-      if (!discovered) continue
-      const dedupeKey = discovered.manifestPath
-      if (!pluginsByManifest.has(dedupeKey)) {
-        pluginsByManifest.set(dedupeKey, discovered)
-      }
-    }
-  }
-
-  const discoveredPlugins = Array.from(pluginsByManifest.values()).sort((a, b) =>
-    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
-  )
-
-  await reconcileLoadedPlugins(discoveredPlugins, homeDir)
-
-  const runtimePlugins = discoveredPlugins.map(toRuntimePlugin)
+  const runtimePlugins = discovery.plugins.map((plugin) => pluginLoader.toRuntimePlugin(plugin))
   const loadWarnings = runtimePlugins
     .filter((plugin) => plugin.loadState === 'failed' && plugin.loadError)
     .map((plugin) => `${plugin.name}: ${plugin.loadError}`)
 
   const snapshot: PluginCatalogSnapshot = {
-    directories: scannedDirectories,
+    directories: discovery.scannedDirectories,
     plugins: runtimePlugins,
     commands: getRegisteredPluginCommands(),
-    warnings: [...discoveryWarnings, ...loadWarnings],
+    warnings: [...discovery.warnings, ...loadWarnings],
     syncedAt: Date.now(),
   }
 
-  lastCatalogSignature = nextSignature
-  updatePluginCatalogSnapshot(snapshot)
+  catalogStore.setSignature(discovery.signature)
+  catalogStore.updateSnapshot(snapshot)
 
   logRendererEvent('info', 'plugin.catalog.synced', {
-    requestedDirectories: normalizedDirs.length,
-    scannedDirectories: scannedDirectories.length,
-    discoveredPlugins: discoveredPlugins.length,
+    requestedDirectories: discovery.normalizedDirs.length,
+    scannedDirectories: discovery.scannedDirectories.length,
+    discoveredPlugins: discovery.plugins.length,
     loadedPlugins: runtimePlugins.filter((plugin) => plugin.loadState === 'loaded').length,
     registeredCommands: snapshot.commands.length,
     warnings: snapshot.warnings.length,
@@ -1015,9 +157,9 @@ export async function syncPluginCatalog(pluginDirs: string[]): Promise<PluginCat
 }
 
 export async function syncPluginCatalogFromProfiles(
-  config: ClaudeProfilesConfig | undefined
+  config: Parameters<typeof collectPluginDirsFromProfilesImpl>[0]
 ): Promise<PluginCatalogSnapshot> {
-  return syncPluginCatalog(collectPluginDirsFromProfiles(config))
+  return syncPluginCatalog(collectPluginDirsFromProfilesImpl(config))
 }
 
 export function registerPluginHook<E extends PluginHookEvent>(
@@ -1025,48 +167,14 @@ export function registerPluginHook<E extends PluginHookEvent>(
   handler: PluginHookHandler<E>,
   options?: { pluginId?: string; order?: number }
 ): () => void {
-  if (!isPluginHookEvent(String(event))) {
-    throw new Error(`Unsupported hook event: ${String(event)}`)
-  }
-  const hook: RegisteredHook<E> = {
-    id: `hook-${++hookCounter}`,
-    event,
-    pluginId: options?.pluginId ?? 'anonymous',
-    order: options?.order ?? 100,
-    handler,
-  }
-  const hooks = getHooksForEvent(event)
-  hooks.push(hook)
-  hooks.sort((a, b) => a.order - b.order)
-
-  return () => {
-    const current = getHooksForEvent(event)
-    const index = current.findIndex((entry) => entry.id === hook.id)
-    if (index >= 0) {
-      current.splice(index, 1)
-    }
-  }
+  return registries.registerHook(event, handler, options)
 }
 
 export async function emitPluginHook<E extends PluginHookEvent>(
   event: E,
   payload: PluginHookEventPayloadMap[E]
 ): Promise<void> {
-  const hooks = getHooksForEvent(event)
-  if (hooks.length === 0) return
-
-  for (const hook of hooks) {
-    try {
-      await hook.handler(payload)
-    } catch (err) {
-      logRendererEvent('error', 'plugin.hook.failed', {
-        event,
-        hookId: hook.id,
-        pluginId: hook.pluginId,
-        error: toErrorMessage(err),
-      })
-    }
-  }
+  await registries.emitHook(event, payload)
 }
 
 function registerBuiltinCommands(): void {
@@ -1079,7 +187,8 @@ function registerBuiltinCommands(): void {
         if (firstArg === 'reload' || firstArg === 'rescan') {
           await syncPluginCatalogFromSettings()
         }
-        const loaded = pluginCatalogSnapshot.plugins.filter((plugin) => plugin.loadState === 'loaded')
+        const snapshot = getPluginCatalogSnapshot()
+        const loaded = snapshot.plugins.filter((plugin) => plugin.loadState === 'loaded')
         const commandNames = getRegisteredPluginCommands().map((command) => `/${command.name}`)
         const pluginList = loaded.length > 0
           ? loaded.map((plugin) => plugin.name).join(', ')
@@ -1100,7 +209,7 @@ function registerBuiltinCommands(): void {
       description: 'Rescan plugin dirs and reload renderer plugin entries.',
       execute: async () => {
         const snapshot = await syncPluginCatalogFromSettings()
-        const current = snapshot ?? pluginCatalogSnapshot
+        const current = snapshot ?? getPluginCatalogSnapshot()
         const loadedCount = current.plugins.filter((plugin) => plugin.loadState === 'loaded').length
         return `Reloaded plugins. Loaded ${loadedCount}/${current.plugins.length}. Warnings: ${current.warnings.length}.`
       },
@@ -1117,7 +226,7 @@ export function initializePluginRuntime(): void {
   registerBuiltinCommands()
   void syncPluginCatalogFromSettings()
   logRendererEvent('info', 'plugin.runtime.initialized', {
-    registeredEvents: Object.entries(hooksByEvent).map(([event, hooks]) => `${event}:${hooks.length}`),
+    registeredEvents: registries.getHookRegistrationSummary(),
     registeredCommands: getRegisteredPluginCommands().map((entry) => entry.name),
     promptTransformers: getRegisteredPromptTransformerCount(),
   })

--- a/src/renderer/plugins/runtime/catalog-store.ts
+++ b/src/renderer/plugins/runtime/catalog-store.ts
@@ -1,0 +1,60 @@
+import type { PluginCatalogSnapshot, PluginCommandSummary } from './contracts'
+
+function createInitialSnapshot(): PluginCatalogSnapshot {
+  return {
+    directories: [],
+    plugins: [],
+    commands: [],
+    warnings: [],
+    syncedAt: 0,
+  }
+}
+
+export interface PluginCatalogStore {
+  getSnapshot: () => PluginCatalogSnapshot
+  subscribe: (listener: () => void) => () => void
+  updateSnapshot: (next: PluginCatalogSnapshot) => void
+  updateCommands: (commands: PluginCommandSummary[]) => void
+  matchesSignature: (signature: string) => boolean
+  setSignature: (signature: string) => void
+}
+
+export function createPluginCatalogStore(): PluginCatalogStore {
+  const listeners = new Set<() => void>()
+  let snapshot = createInitialSnapshot()
+  let lastSignature = ''
+
+  const updateSnapshot = (next: PluginCatalogSnapshot): void => {
+    snapshot = next
+    for (const listener of listeners) {
+      try {
+        listener()
+      } catch (err) {
+        console.error('[plugins] listener failure:', err)
+      }
+    }
+  }
+
+  return {
+    getSnapshot: () => snapshot,
+    subscribe: (listener) => {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+    updateSnapshot,
+    updateCommands: (commands) => {
+      if (snapshot.syncedAt === 0) return
+      updateSnapshot({
+        ...snapshot,
+        commands,
+        syncedAt: Date.now(),
+      })
+    },
+    matchesSignature: (signature) => signature === lastSignature,
+    setSignature: (signature) => {
+      lastSignature = signature
+    },
+  }
+}

--- a/src/renderer/plugins/runtime/contracts.ts
+++ b/src/renderer/plugins/runtime/contracts.ts
@@ -1,0 +1,187 @@
+import type {
+  ClaudeProfilesConfig,
+  PluginHookEvent,
+  PluginHookEventPayloadMap,
+  PluginHookHandler,
+} from '../../types'
+
+export type { ClaudeProfilesConfig, PluginHookEvent, PluginHookEventPayloadMap, PluginHookHandler }
+
+export const PLUGIN_HOOK_EVENTS: PluginHookEvent[] = [
+  'before_agent_start',
+  'agent_end',
+  'session_start',
+  'session_end',
+  'message_received',
+  'message_sending',
+  'message_sent',
+  'before_tool_call',
+  'after_tool_call',
+  'tool_result_persist',
+]
+
+export interface RegisteredHook<E extends PluginHookEvent = PluginHookEvent> {
+  id: string
+  event: E
+  pluginId: string
+  order: number
+  handler: PluginHookHandler<E>
+}
+
+export interface RegisteredPluginCommand {
+  id: string
+  name: string
+  pluginId: string
+  description: string | null
+  execute: PluginCommandDefinition['execute']
+}
+
+export interface RegisteredPromptTransformer {
+  id: string
+  pluginId: string
+  order: number
+  transform: PluginPromptTransformerDefinition['transform']
+}
+
+export type HooksByEvent = {
+  [E in PluginHookEvent]: RegisteredHook<E>[]
+}
+
+export type PluginLoadState = 'loaded' | 'failed' | 'skipped'
+
+export interface RawDiscoveredPlugin {
+  id: string
+  name: string
+  version: string
+  description: string | null
+  rootDir: string
+  manifestPath: string
+  source: 'agent-observer.plugin.json' | 'openclaw.plugin.json' | 'package.json'
+  rendererEntry: string | null
+}
+
+export interface RuntimeDiscoveredPlugin extends RawDiscoveredPlugin {
+  loadState: PluginLoadState
+  loadError: string | null
+}
+
+export interface PluginCommandContext {
+  chatSessionId: string
+  workspaceDirectory: string | null
+  agentId: string | null
+  rawMessage: string
+  argsRaw: string
+  args: string[]
+  attachmentNames: string[]
+  mentionPaths: string[]
+}
+
+export interface PluginCommandDefinition {
+  name: string
+  description?: string
+  execute: (
+    context: PluginCommandContext
+  ) =>
+    | void
+    | string
+    | { message?: string; isError?: boolean; error?: string }
+    | Promise<void | string | { message?: string; isError?: boolean; error?: string }>
+}
+
+export interface PluginCommandSummary {
+  name: string
+  pluginId: string
+  description: string | null
+}
+
+export interface PluginCommandExecutionResult {
+  handled: boolean
+  commandName: string
+  pluginId: string | null
+  message: string | null
+  isError: boolean
+}
+
+export interface PluginPromptTransformContext {
+  chatSessionId: string
+  workspaceDirectory: string | null
+  agentId: string | null
+  rawMessage: string
+  prompt: string
+  mentionCount: number
+  attachmentCount: number
+}
+
+export interface PluginPromptTransformerDefinition {
+  transform: (
+    context: PluginPromptTransformContext
+  ) =>
+    | void
+    | string
+    | { prompt?: string; cancel?: boolean; error?: string }
+    | Promise<void | string | { prompt?: string; cancel?: boolean; error?: string }>
+}
+
+export interface PluginPromptTransformApplyResult {
+  prompt: string
+  transformed: boolean
+  canceled: boolean
+  errorMessage: string | null
+}
+
+export interface PluginHookDefinition<E extends PluginHookEvent = PluginHookEvent> {
+  event: E
+  handler: PluginHookHandler<E>
+  order?: number
+}
+
+export interface PluginCatalogSnapshot {
+  directories: string[]
+  plugins: RuntimeDiscoveredPlugin[]
+  commands: PluginCommandSummary[]
+  warnings: string[]
+  syncedAt: number
+}
+
+export interface LoadedPluginInstance {
+  entryPath: string
+  dispose: () => void
+}
+
+export interface PluginModule {
+  default?: unknown
+  register?: unknown
+}
+
+export interface RendererPluginApi {
+  registerHook: <E extends PluginHookEvent>(
+    event: E | PluginHookDefinition<E>,
+    handler?: PluginHookHandler<E>,
+    options?: { order?: number }
+  ) => () => void
+  on: <E extends PluginHookEvent>(
+    event: E,
+    handler: PluginHookHandler<E>,
+    options?: { order?: number }
+  ) => () => void
+  registerCommand: (
+    command: PluginCommandDefinition
+  ) => () => void
+  registerPromptTransformer: (
+    transformer: PluginPromptTransformerDefinition,
+    options?: { order?: number }
+  ) => () => void
+  log: (level: 'info' | 'warn' | 'error', event: string, payload?: Record<string, unknown>) => void
+  plugin: RawDiscoveredPlugin
+}
+
+export type RegisterPluginFunction = (api: RendererPluginApi) => unknown | Promise<unknown>
+
+export interface PluginDiscoveryResult {
+  normalizedDirs: string[]
+  scannedDirectories: string[]
+  plugins: RawDiscoveredPlugin[]
+  warnings: string[]
+  homeDir: string
+  signature: string
+}

--- a/src/renderer/plugins/runtime/discovery.ts
+++ b/src/renderer/plugins/runtime/discovery.ts
@@ -1,0 +1,209 @@
+import type { ClaudeProfilesConfig } from '../../types'
+import type {
+  PluginDiscoveryResult,
+  RawDiscoveredPlugin,
+} from './contracts'
+import {
+  asRecord,
+  asString,
+  asStringArray,
+  dedupePreserveOrder,
+  getPathBaseName,
+  isAbsolutePath,
+  joinPath,
+  replaceTildePrefix,
+} from './helpers'
+
+const IGNORED_CHILD_DIRS = new Set([
+  'node_modules',
+  '.git',
+  '.next',
+  'dist',
+  'build',
+  'out',
+  '.turbo',
+  '.pnpm-store',
+  '.yarn',
+  '.cache',
+])
+
+async function readJsonFile(filePath: string): Promise<Record<string, unknown> | null> {
+  try {
+    const file = await window.electronAPI.fs.readFile(filePath)
+    const parsed = JSON.parse(file.content) as unknown
+    return asRecord(parsed)
+  } catch {
+    return null
+  }
+}
+
+function readManifestMetadata(
+  raw: Record<string, unknown>,
+  fallbackName: string
+): { id: string; name: string; version: string; description: string | null; rendererEntry: string | null } {
+  const name = asString(raw.name) ?? fallbackName
+  const version = asString(raw.version) ?? '0.0.0'
+  const description = asString(raw.description)
+  const rendererEntry = asString(raw.rendererEntry)
+    ?? asString(raw.entry)
+    ?? asString(raw.main)
+    ?? null
+  return {
+    id: asString(raw.id) ?? name,
+    name,
+    version,
+    description,
+    rendererEntry,
+  }
+}
+
+async function detectPluginAtRoot(rootDir: string): Promise<RawDiscoveredPlugin | null> {
+  const fallbackName = getPathBaseName(rootDir)
+
+  const agentSpaceManifestPath = joinPath(rootDir, 'agent-observer.plugin.json')
+  const agentSpaceManifest = await readJsonFile(agentSpaceManifestPath)
+  if (agentSpaceManifest) {
+    const metadata = readManifestMetadata(agentSpaceManifest, fallbackName)
+    return {
+      ...metadata,
+      rootDir,
+      manifestPath: agentSpaceManifestPath,
+      source: 'agent-observer.plugin.json',
+    }
+  }
+
+  const openClawManifestPath = joinPath(rootDir, 'openclaw.plugin.json')
+  const openClawManifest = await readJsonFile(openClawManifestPath)
+  if (openClawManifest) {
+    const metadata = readManifestMetadata(openClawManifest, fallbackName)
+    return {
+      ...metadata,
+      rootDir,
+      manifestPath: openClawManifestPath,
+      source: 'openclaw.plugin.json',
+    }
+  }
+
+  const packagePath = joinPath(rootDir, 'package.json')
+  const packageJson = await readJsonFile(packagePath)
+  if (!packageJson) return null
+
+  const openClawConfig = asRecord(packageJson.openclaw)
+  const agentSpaceConfig = asRecord(packageJson.agentSpace)
+  const extensionEntries = asStringArray(openClawConfig?.extensions)
+  const packageKeywords = asStringArray(packageJson.keywords)
+  const hasPluginKeyword = packageKeywords.some((keyword) =>
+    keyword === 'openclaw-plugin' || keyword === 'agent-observer-plugin'
+  )
+  const metadata = readManifestMetadata(packageJson, fallbackName)
+  const rendererEntryFromConfig = asString(agentSpaceConfig?.rendererEntry)
+    ?? asString(openClawConfig?.rendererEntry)
+    ?? extensionEntries[0]
+    ?? null
+
+  if (!hasPluginKeyword && extensionEntries.length === 0 && !rendererEntryFromConfig) {
+    return null
+  }
+
+  return {
+    ...metadata,
+    rendererEntry: rendererEntryFromConfig ?? metadata.rendererEntry,
+    rootDir,
+    manifestPath: packagePath,
+    source: 'package.json',
+  }
+}
+
+async function listCandidatePluginRoots(directory: string): Promise<string[]> {
+  const roots = [directory]
+  try {
+    const entries = await window.electronAPI.fs.readDir(directory)
+    for (const entry of entries) {
+      if (!entry.isDirectory) continue
+      if (entry.name.startsWith('.')) continue
+      if (IGNORED_CHILD_DIRS.has(entry.name)) continue
+      roots.push(entry.path)
+      if (roots.length >= 80) break
+    }
+  } catch {
+    // Keep root-only scan if we fail to enumerate children.
+  }
+  return roots
+}
+
+export async function resolveRendererEntryPath(
+  plugin: RawDiscoveredPlugin,
+  homeDir: string
+): Promise<string | null> {
+  if (!plugin.rendererEntry) return null
+  const expanded = replaceTildePrefix(plugin.rendererEntry, homeDir)
+  return isAbsolutePath(expanded) ? expanded : joinPath(plugin.rootDir, expanded)
+}
+
+export function collectPluginDirsFromProfiles(config: ClaudeProfilesConfig | undefined): string[] {
+  if (!config) return []
+  return dedupePreserveOrder(
+    config.profiles.flatMap((profile) => profile.pluginDirs.map((path) => path.trim()))
+  )
+}
+
+export async function discoverPlugins(pluginDirs: string[]): Promise<PluginDiscoveryResult> {
+  if (!window.electronAPI?.fs) {
+    return {
+      normalizedDirs: [],
+      scannedDirectories: [],
+      plugins: [],
+      warnings: [],
+      homeDir: '',
+      signature: '',
+    }
+  }
+
+  const normalizedInputDirs = dedupePreserveOrder(pluginDirs)
+  const homeDir = await window.electronAPI.fs.homeDir()
+  const normalizedDirs = dedupePreserveOrder(
+    normalizedInputDirs.map((dir) => replaceTildePrefix(dir, homeDir))
+  )
+  const signature = normalizedDirs.join('::')
+
+  const warnings: string[] = []
+  const pluginsByManifest = new Map<string, RawDiscoveredPlugin>()
+  const scannedDirectories: string[] = []
+
+  for (const directory of normalizedDirs) {
+    try {
+      const stat = await window.electronAPI.fs.stat(directory)
+      if (!stat.isDirectory) {
+        warnings.push(`Plugin dir is not a directory: ${directory}`)
+        continue
+      }
+    } catch {
+      warnings.push(`Plugin dir not found: ${directory}`)
+      continue
+    }
+
+    scannedDirectories.push(directory)
+    const roots = await listCandidatePluginRoots(directory)
+    for (const rootDir of roots) {
+      const discovered = await detectPluginAtRoot(rootDir)
+      if (!discovered) continue
+      const dedupeKey = discovered.manifestPath
+      if (!pluginsByManifest.has(dedupeKey)) {
+        pluginsByManifest.set(dedupeKey, discovered)
+      }
+    }
+  }
+
+  const plugins = Array.from(pluginsByManifest.values()).sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+  )
+
+  return {
+    normalizedDirs,
+    scannedDirectories,
+    plugins,
+    warnings,
+    homeDir,
+    signature,
+  }
+}

--- a/src/renderer/plugins/runtime/helpers.ts
+++ b/src/renderer/plugins/runtime/helpers.ts
@@ -1,0 +1,151 @@
+import { logRendererEvent } from '../../lib/diagnostics'
+
+export function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== 'object' || value === null) return null
+  return value as Record<string, unknown>
+}
+
+export function asString(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed ? trimmed : null
+}
+
+export function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value
+    .map((entry) => asString(entry))
+    .filter((entry): entry is string => Boolean(entry))
+}
+
+export function asFiniteNumber(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+  return value
+}
+
+export function dedupePreserveOrder(values: string[]): string[] {
+  const seen = new Set<string>()
+  const next: string[] = []
+  for (const value of values) {
+    const trimmed = value.trim()
+    if (!trimmed || seen.has(trimmed)) continue
+    seen.add(trimmed)
+    next.push(trimmed)
+  }
+  return next
+}
+
+export function getPathBaseName(targetPath: string): string {
+  const normalized = targetPath.replace(/\\/g, '/').replace(/\/+$/, '')
+  const parts = normalized.split('/').filter(Boolean)
+  return parts[parts.length - 1] ?? targetPath
+}
+
+export function joinPath(base: string, name: string): string {
+  if (base.endsWith('/') || base.endsWith('\\')) return `${base}${name}`
+  return `${base}/${name}`
+}
+
+export function isAbsolutePath(input: string): boolean {
+  return input.startsWith('/')
+    || /^[a-zA-Z]:[\\/]/.test(input)
+    || input.startsWith('\\\\')
+}
+
+export function replaceTildePrefix(rawPath: string, homeDir: string): string {
+  if (rawPath === '~') return homeDir
+  if (rawPath.startsWith('~/') || rawPath.startsWith('~\\')) {
+    return `${homeDir}${rawPath.slice(1)}`
+  }
+  return rawPath
+}
+
+export function toFileModuleSpecifier(filePath: string, versionTag?: number): string {
+  const normalized = filePath.replace(/\\/g, '/')
+  const base = /^[a-zA-Z]:\//.test(normalized)
+    ? `file:///${normalized}`
+    : `file://${normalized}`
+  const encoded = encodeURI(base)
+  if (!versionTag || !Number.isFinite(versionTag)) return encoded
+  return `${encoded}?v=${Math.floor(versionTag)}`
+}
+
+export function toErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+export function runDisposer(
+  disposer: (() => void) | null | undefined,
+  context: string,
+  pluginId?: string
+): void {
+  if (!disposer) return
+  try {
+    disposer()
+  } catch (err) {
+    logRendererEvent('warn', 'plugin.runtime.dispose_failed', {
+      context,
+      pluginId,
+      error: toErrorMessage(err),
+    })
+  }
+}
+
+export function normalizeCommandName(rawName: string): string | null {
+  const trimmed = rawName.trim()
+  if (!trimmed) return null
+  const withoutPrefix = trimmed.startsWith('/') ? trimmed.slice(1) : trimmed
+  const normalized = withoutPrefix.trim().toLowerCase()
+  if (!normalized) return null
+  if (!/^[a-z0-9._-]+$/.test(normalized)) return null
+  return normalized
+}
+
+export function normalizeCommandExecutionOutput(
+  output: unknown
+): { message: string | null; isError: boolean } {
+  if (output === null || output === undefined) {
+    return { message: null, isError: false }
+  }
+  if (typeof output === 'string') {
+    const message = output.trim()
+    return { message: message || null, isError: false }
+  }
+  const record = asRecord(output)
+  if (record) {
+    const messageFromMessage = asString(record.message)
+    const messageFromError = asString(record.error)
+    const isError = record.isError === true || Boolean(messageFromError)
+    if (messageFromMessage) {
+      return { message: messageFromMessage, isError }
+    }
+    if (messageFromError) {
+      return { message: messageFromError, isError: true }
+    }
+  }
+  try {
+    return { message: JSON.stringify(output), isError: false }
+  } catch {
+    return { message: String(output), isError: false }
+  }
+}
+
+export function normalizePromptTransformOutput(
+  output: unknown
+): { nextPrompt: string | null; cancel: boolean; errorMessage: string | null } {
+  if (output === null || output === undefined) {
+    return { nextPrompt: null, cancel: false, errorMessage: null }
+  }
+  if (typeof output === 'string') {
+    return { nextPrompt: output, cancel: false, errorMessage: null }
+  }
+  const record = asRecord(output)
+  if (!record) {
+    return { nextPrompt: null, cancel: false, errorMessage: null }
+  }
+  return {
+    nextPrompt: asString(record.prompt),
+    cancel: record.cancel === true,
+    errorMessage: asString(record.error),
+  }
+}

--- a/src/renderer/plugins/runtime/loader.ts
+++ b/src/renderer/plugins/runtime/loader.ts
@@ -1,0 +1,243 @@
+import { logRendererEvent } from '../../lib/diagnostics'
+import type {
+  LoadedPluginInstance,
+  PluginCommandDefinition,
+  PluginHookDefinition,
+  PluginHookEvent,
+  PluginHookHandler,
+  PluginModule,
+  PluginPromptTransformerDefinition,
+  RawDiscoveredPlugin,
+  RegisterPluginFunction,
+  RendererPluginApi,
+  RuntimeDiscoveredPlugin,
+} from './contracts'
+import { resolveRendererEntryPath } from './discovery'
+import {
+  asRecord,
+  runDisposer,
+  toErrorMessage,
+  toFileModuleSpecifier,
+} from './helpers'
+
+export interface PluginLoaderRegistrationApi {
+  registerHookFromDefinition: <E extends PluginHookEvent>(
+    event: E | PluginHookDefinition<E>,
+    handler?: PluginHookHandler<E>,
+    options?: { pluginId?: string; order?: number }
+  ) => () => void
+  registerCommand: (
+    command: PluginCommandDefinition,
+    options?: { pluginId?: string }
+  ) => () => void
+  registerPromptTransformer: (
+    transformer: PluginPromptTransformerDefinition,
+    options?: { pluginId?: string; order?: number }
+  ) => () => void
+}
+
+export interface PluginLoader {
+  reconcileLoadedPlugins: (
+    plugins: RawDiscoveredPlugin[],
+    homeDir: string
+  ) => Promise<void>
+  toRuntimePlugin: (plugin: RawDiscoveredPlugin) => RuntimeDiscoveredPlugin
+}
+
+export function createPluginLoader(registrations: PluginLoaderRegistrationApi): PluginLoader {
+  const loadedPluginInstances = new Map<string, LoadedPluginInstance>()
+  const pluginLoadErrors = new Map<string, string>()
+
+  const loadPluginModule = async (
+    plugin: RawDiscoveredPlugin,
+    entryPath: string
+  ): Promise<LoadedPluginInstance> => {
+    const stat = await window.electronAPI.fs.stat(entryPath)
+    if (!stat.isFile) {
+      throw new Error(`Renderer entry is not a file: ${entryPath}`)
+    }
+
+    const moduleSpecifier = toFileModuleSpecifier(entryPath, stat.modified)
+    const moduleExports = await import(/* @vite-ignore */ moduleSpecifier) as PluginModule
+    const registerCandidate = typeof moduleExports.default === 'function'
+      ? moduleExports.default
+      : moduleExports.register
+    if (typeof registerCandidate !== 'function') {
+      throw new Error('Plugin module must export default function register(api) or named register(api)')
+    }
+
+    const hookDisposers: Array<() => void> = []
+    const registerHookFromPlugin = <E extends PluginHookEvent>(
+      event: E | PluginHookDefinition<E>,
+      handler?: PluginHookHandler<E>,
+      options?: { order?: number }
+    ): (() => void) => {
+      const dispose = registrations.registerHookFromDefinition(event, handler, {
+        pluginId: plugin.id,
+        order: options?.order,
+      })
+      hookDisposers.push(dispose)
+      return () => {
+        const index = hookDisposers.indexOf(dispose)
+        if (index >= 0) hookDisposers.splice(index, 1)
+        runDisposer(dispose, 'hook_unregister', plugin.id)
+      }
+    }
+
+    const commandDisposers: Array<() => void> = []
+    const registerCommandFromPlugin = (command: PluginCommandDefinition): (() => void) => {
+      const dispose = registrations.registerCommand(command, { pluginId: plugin.id })
+      commandDisposers.push(dispose)
+      return () => {
+        const index = commandDisposers.indexOf(dispose)
+        if (index >= 0) commandDisposers.splice(index, 1)
+        runDisposer(dispose, 'command_unregister', plugin.id)
+      }
+    }
+
+    const promptTransformDisposers: Array<() => void> = []
+    const registerPromptTransformerFromPlugin = (
+      transformer: PluginPromptTransformerDefinition,
+      options?: { order?: number }
+    ): (() => void) => {
+      const dispose = registrations.registerPromptTransformer(transformer, {
+        pluginId: plugin.id,
+        order: options?.order,
+      })
+      promptTransformDisposers.push(dispose)
+      return () => {
+        const index = promptTransformDisposers.indexOf(dispose)
+        if (index >= 0) promptTransformDisposers.splice(index, 1)
+        runDisposer(dispose, 'prompt_transform_unregister', plugin.id)
+      }
+    }
+
+    const api: RendererPluginApi = {
+      registerHook: registerHookFromPlugin,
+      on: registerHookFromPlugin,
+      registerCommand: registerCommandFromPlugin,
+      registerPromptTransformer: registerPromptTransformerFromPlugin,
+      log: (level, event, payload) => {
+        logRendererEvent(level, `plugin.${plugin.id}.${event}`, payload)
+      },
+      plugin,
+    }
+
+    const pluginCleanupCandidates: Array<() => void> = []
+    const register = registerCandidate as RegisterPluginFunction
+    const registrationResult = await register(api)
+    if (typeof registrationResult === 'function') {
+      pluginCleanupCandidates.push(registrationResult as () => void)
+    } else {
+      const registrationRecord = asRecord(registrationResult)
+      const disposeMaybe = registrationRecord?.dispose
+      if (typeof disposeMaybe === 'function') {
+        pluginCleanupCandidates.push(disposeMaybe as () => void)
+      }
+    }
+
+    const dispose = (): void => {
+      while (pluginCleanupCandidates.length > 0) {
+        const candidate = pluginCleanupCandidates.pop()
+        runDisposer(candidate, 'plugin_unregister', plugin.id)
+      }
+      while (commandDisposers.length > 0) {
+        const commandDispose = commandDisposers.pop()
+        runDisposer(commandDispose, 'command_unregister', plugin.id)
+      }
+      while (promptTransformDisposers.length > 0) {
+        const promptTransformDispose = promptTransformDisposers.pop()
+        runDisposer(promptTransformDispose, 'prompt_transform_unregister', plugin.id)
+      }
+      while (hookDisposers.length > 0) {
+        const hookDispose = hookDisposers.pop()
+        runDisposer(hookDispose, 'hook_unregister', plugin.id)
+      }
+    }
+
+    return { entryPath, dispose }
+  }
+
+  const reconcileLoadedPlugins = async (
+    plugins: RawDiscoveredPlugin[],
+    homeDir: string
+  ): Promise<void> => {
+    const desiredEntryPaths = new Map<string, string | null>()
+    for (const plugin of plugins) {
+      desiredEntryPaths.set(plugin.manifestPath, await resolveRendererEntryPath(plugin, homeDir))
+    }
+
+    for (const [manifestPath, instance] of loadedPluginInstances) {
+      const desiredEntryPath = desiredEntryPaths.get(manifestPath)
+      if (!desiredEntryPath || desiredEntryPath !== instance.entryPath) {
+        runDisposer(instance.dispose, 'plugin_reload', manifestPath)
+        loadedPluginInstances.delete(manifestPath)
+      }
+    }
+
+    for (const manifestPath of Array.from(pluginLoadErrors.keys())) {
+      if (!desiredEntryPaths.has(manifestPath)) {
+        pluginLoadErrors.delete(manifestPath)
+      }
+    }
+
+    for (const plugin of plugins) {
+      const entryPath = desiredEntryPaths.get(plugin.manifestPath) ?? null
+      if (!entryPath) {
+        pluginLoadErrors.delete(plugin.manifestPath)
+        continue
+      }
+      if (loadedPluginInstances.has(plugin.manifestPath)) {
+        pluginLoadErrors.delete(plugin.manifestPath)
+        continue
+      }
+
+      try {
+        const instance = await loadPluginModule(plugin, entryPath)
+        loadedPluginInstances.set(plugin.manifestPath, instance)
+        pluginLoadErrors.delete(plugin.manifestPath)
+        logRendererEvent('info', 'plugin.runtime.loaded', {
+          pluginId: plugin.id,
+          manifestPath: plugin.manifestPath,
+          entryPath,
+        })
+      } catch (err) {
+        const message = toErrorMessage(err)
+        pluginLoadErrors.set(plugin.manifestPath, message)
+        logRendererEvent('warn', 'plugin.runtime.load_failed', {
+          pluginId: plugin.id,
+          manifestPath: plugin.manifestPath,
+          entryPath,
+          error: message,
+        })
+      }
+    }
+  }
+
+  const toRuntimePlugin = (plugin: RawDiscoveredPlugin): RuntimeDiscoveredPlugin => {
+    if (!plugin.rendererEntry) {
+      return {
+        ...plugin,
+        loadState: 'skipped',
+        loadError: null,
+      }
+    }
+    if (loadedPluginInstances.has(plugin.manifestPath)) {
+      return {
+        ...plugin,
+        loadState: 'loaded',
+        loadError: null,
+      }
+    }
+    return {
+      ...plugin,
+      loadState: 'failed',
+      loadError: pluginLoadErrors.get(plugin.manifestPath) ?? 'Renderer entry failed to load',
+    }
+  }
+
+  return {
+    reconcileLoadedPlugins,
+    toRuntimePlugin,
+  }
+}

--- a/src/renderer/plugins/runtime/registries.ts
+++ b/src/renderer/plugins/runtime/registries.ts
@@ -1,0 +1,388 @@
+import { logRendererEvent } from '../../lib/diagnostics'
+import type {
+  HooksByEvent,
+  PluginCommandContext,
+  PluginCommandDefinition,
+  PluginCommandExecutionResult,
+  PluginCommandSummary,
+  PluginHookDefinition,
+  PluginHookEvent,
+  PluginHookEventPayloadMap,
+  PluginHookHandler,
+  PluginPromptTransformApplyResult,
+  PluginPromptTransformContext,
+  PluginPromptTransformerDefinition,
+  RegisteredHook,
+  RegisteredPluginCommand,
+  RegisteredPromptTransformer,
+} from './contracts'
+import {
+  asFiniteNumber,
+  asRecord,
+  asString,
+  normalizeCommandExecutionOutput,
+  normalizeCommandName,
+  normalizePromptTransformOutput,
+  toErrorMessage,
+} from './helpers'
+import { PLUGIN_HOOK_EVENTS } from './contracts'
+
+function createHooksByEvent(): HooksByEvent {
+  return {
+    before_agent_start: [],
+    agent_end: [],
+    session_start: [],
+    session_end: [],
+    message_received: [],
+    message_sending: [],
+    message_sent: [],
+    before_tool_call: [],
+    after_tool_call: [],
+    tool_result_persist: [],
+  }
+}
+
+export interface PluginRegistries {
+  registerHook: <E extends PluginHookEvent>(
+    event: E,
+    handler: PluginHookHandler<E>,
+    options?: { pluginId?: string; order?: number }
+  ) => () => void
+  registerHookFromDefinition: <E extends PluginHookEvent>(
+    event: E | PluginHookDefinition<E>,
+    handler?: PluginHookHandler<E>,
+    options?: { pluginId?: string; order?: number }
+  ) => () => void
+  emitHook: <E extends PluginHookEvent>(
+    event: E,
+    payload: PluginHookEventPayloadMap[E]
+  ) => Promise<void>
+  registerCommand: (
+    command: PluginCommandDefinition,
+    options?: { pluginId?: string }
+  ) => () => void
+  invokeCommand: (
+    commandName: string,
+    context: PluginCommandContext
+  ) => Promise<PluginCommandExecutionResult>
+  getRegisteredCommands: () => PluginCommandSummary[]
+  registerPromptTransformer: (
+    transformer: PluginPromptTransformerDefinition,
+    options?: { pluginId?: string; order?: number }
+  ) => () => void
+  applyPromptTransforms: (
+    context: PluginPromptTransformContext
+  ) => Promise<PluginPromptTransformApplyResult>
+  getPromptTransformerCount: () => number
+  getHookRegistrationSummary: () => string[]
+}
+
+export function createPluginRegistries(): PluginRegistries {
+  const hooksByEvent = createHooksByEvent()
+  const hookEvents = new Set<PluginHookEvent>(PLUGIN_HOOK_EVENTS)
+  const pluginCommandsByName = new Map<string, RegisteredPluginCommand>()
+  const promptTransformers: RegisteredPromptTransformer[] = []
+  let hookCounter = 0
+  let commandCounter = 0
+  let promptTransformerCounter = 0
+
+  const isPluginHookEvent = (value: string): value is PluginHookEvent => {
+    return hookEvents.has(value as PluginHookEvent)
+  }
+
+  const normalizeHookRegistration = <E extends PluginHookEvent>(
+    event: E | PluginHookDefinition<E>,
+    handler?: PluginHookHandler<E>,
+    options?: { order?: number }
+  ): { event: E; handler: PluginHookHandler<E>; order?: number } => {
+    if (typeof event === 'string') {
+      if (typeof handler !== 'function') {
+        throw new Error(`Hook "${event}" requires a handler function`)
+      }
+      return {
+        event,
+        handler,
+        order: options?.order,
+      }
+    }
+
+    const registration = asRecord(event as unknown)
+    if (!registration) {
+      throw new Error('Hook registration must be a string event or object definition')
+    }
+
+    const rawEvent = asString(registration.event)
+    if (!rawEvent || !isPluginHookEvent(rawEvent)) {
+      throw new Error(`Unsupported hook event: ${String(registration.event)}`)
+    }
+
+    if (typeof registration.handler !== 'function') {
+      throw new Error(`Hook "${rawEvent}" requires a handler function`)
+    }
+
+    return {
+      event: rawEvent as E,
+      handler: registration.handler as PluginHookHandler<E>,
+      order: asFiniteNumber(registration.order) ?? options?.order,
+    }
+  }
+
+  const getHooksForEvent = <E extends PluginHookEvent>(event: E): RegisteredHook<E>[] => {
+    return hooksByEvent[event]
+  }
+
+  const registerHook = <E extends PluginHookEvent>(
+    event: E,
+    handler: PluginHookHandler<E>,
+    options?: { pluginId?: string; order?: number }
+  ): (() => void) => {
+    if (!isPluginHookEvent(String(event))) {
+      throw new Error(`Unsupported hook event: ${String(event)}`)
+    }
+    const hook: RegisteredHook<E> = {
+      id: `hook-${++hookCounter}`,
+      event,
+      pluginId: options?.pluginId ?? 'anonymous',
+      order: options?.order ?? 100,
+      handler,
+    }
+    const hooks = getHooksForEvent(event)
+    hooks.push(hook)
+    hooks.sort((a, b) => a.order - b.order)
+
+    return () => {
+      const current = getHooksForEvent(event)
+      const index = current.findIndex((entry) => entry.id === hook.id)
+      if (index >= 0) {
+        current.splice(index, 1)
+      }
+    }
+  }
+
+  const registerHookFromDefinition = <E extends PluginHookEvent>(
+    event: E | PluginHookDefinition<E>,
+    handler?: PluginHookHandler<E>,
+    options?: { pluginId?: string; order?: number }
+  ): (() => void) => {
+    const normalized = normalizeHookRegistration(event, handler, options)
+    return registerHook(normalized.event, normalized.handler, {
+      pluginId: options?.pluginId,
+      order: normalized.order,
+    })
+  }
+
+  const emitHook = async <E extends PluginHookEvent>(
+    event: E,
+    payload: PluginHookEventPayloadMap[E]
+  ): Promise<void> => {
+    const hooks = getHooksForEvent(event)
+    if (hooks.length === 0) return
+
+    for (const hook of hooks) {
+      try {
+        await hook.handler(payload)
+      } catch (err) {
+        logRendererEvent('error', 'plugin.hook.failed', {
+          event,
+          hookId: hook.id,
+          pluginId: hook.pluginId,
+          error: toErrorMessage(err),
+        })
+      }
+    }
+  }
+
+  const registerCommand = (
+    command: PluginCommandDefinition,
+    options?: { pluginId?: string }
+  ): (() => void) => {
+    const normalizedName = normalizeCommandName(command.name)
+    if (!normalizedName) {
+      throw new Error(`Invalid plugin command name: ${command.name}`)
+    }
+
+    const registered: RegisteredPluginCommand = {
+      id: `command-${++commandCounter}`,
+      name: normalizedName,
+      pluginId: options?.pluginId ?? 'anonymous',
+      description: asString(command.description) ?? null,
+      execute: command.execute,
+    }
+
+    const existing = pluginCommandsByName.get(normalizedName)
+    if (existing && existing.id !== registered.id) {
+      logRendererEvent('warn', 'plugin.command.replaced', {
+        commandName: normalizedName,
+        replacedPluginId: existing.pluginId,
+        pluginId: registered.pluginId,
+      })
+    }
+
+    pluginCommandsByName.set(normalizedName, registered)
+
+    return () => {
+      const current = pluginCommandsByName.get(normalizedName)
+      if (!current || current.id !== registered.id) return
+      pluginCommandsByName.delete(normalizedName)
+    }
+  }
+
+  const invokeCommand = async (
+    commandName: string,
+    context: PluginCommandContext
+  ): Promise<PluginCommandExecutionResult> => {
+    const normalizedName = normalizeCommandName(commandName)
+    if (!normalizedName) {
+      return {
+        handled: false,
+        commandName: commandName.trim(),
+        pluginId: null,
+        message: null,
+        isError: false,
+      }
+    }
+
+    const command = pluginCommandsByName.get(normalizedName)
+    if (!command) {
+      return {
+        handled: false,
+        commandName: normalizedName,
+        pluginId: null,
+        message: null,
+        isError: false,
+      }
+    }
+
+    try {
+      const output = await command.execute(context)
+      const normalizedOutput = normalizeCommandExecutionOutput(output)
+      logRendererEvent('info', 'plugin.command.executed', {
+        pluginId: command.pluginId,
+        commandName: normalizedName,
+        hasMessage: Boolean(normalizedOutput.message),
+        isError: normalizedOutput.isError,
+      })
+      return {
+        handled: true,
+        commandName: normalizedName,
+        pluginId: command.pluginId,
+        message: normalizedOutput.message,
+        isError: normalizedOutput.isError,
+      }
+    } catch (err) {
+      const errorMessage = toErrorMessage(err)
+      logRendererEvent('warn', 'plugin.command.failed', {
+        pluginId: command.pluginId,
+        commandName: normalizedName,
+        error: errorMessage,
+      })
+      return {
+        handled: true,
+        commandName: normalizedName,
+        pluginId: command.pluginId,
+        message: errorMessage,
+        isError: true,
+      }
+    }
+  }
+
+  const getRegisteredCommands = (): PluginCommandSummary[] => {
+    return Array.from(pluginCommandsByName.values())
+      .map((command) => ({
+        name: command.name,
+        pluginId: command.pluginId,
+        description: command.description,
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }))
+  }
+
+  const registerPromptTransformer = (
+    transformer: PluginPromptTransformerDefinition,
+    options?: { pluginId?: string; order?: number }
+  ): (() => void) => {
+    const entry: RegisteredPromptTransformer = {
+      id: `prompt-transformer-${++promptTransformerCounter}`,
+      pluginId: options?.pluginId ?? 'anonymous',
+      order: options?.order ?? 100,
+      transform: transformer.transform,
+    }
+    promptTransformers.push(entry)
+    promptTransformers.sort((a, b) => a.order - b.order)
+
+    return () => {
+      const index = promptTransformers.findIndex((candidate) => candidate.id === entry.id)
+      if (index >= 0) {
+        promptTransformers.splice(index, 1)
+      }
+    }
+  }
+
+  const applyPromptTransforms = async (
+    context: PluginPromptTransformContext
+  ): Promise<PluginPromptTransformApplyResult> => {
+    if (promptTransformers.length === 0) {
+      return {
+        prompt: context.prompt,
+        transformed: false,
+        canceled: false,
+        errorMessage: null,
+      }
+    }
+
+    let currentPrompt = context.prompt
+    let transformed = false
+
+    for (const transformer of promptTransformers) {
+      try {
+        const output = await transformer.transform({
+          ...context,
+          prompt: currentPrompt,
+        })
+        const normalizedOutput = normalizePromptTransformOutput(output)
+        if (typeof normalizedOutput.nextPrompt === 'string') {
+          if (normalizedOutput.nextPrompt !== currentPrompt) {
+            transformed = true
+          }
+          currentPrompt = normalizedOutput.nextPrompt
+        }
+        if (normalizedOutput.cancel) {
+          return {
+            prompt: currentPrompt,
+            transformed,
+            canceled: true,
+            errorMessage: normalizedOutput.errorMessage
+              ?? `Prompt canceled by plugin ${transformer.pluginId}`,
+          }
+        }
+      } catch (err) {
+        logRendererEvent('warn', 'plugin.prompt_transform.failed', {
+          pluginId: transformer.pluginId,
+          transformerId: transformer.id,
+          error: toErrorMessage(err),
+        })
+      }
+    }
+
+    return {
+      prompt: currentPrompt,
+      transformed,
+      canceled: false,
+      errorMessage: null,
+    }
+  }
+
+  return {
+    registerHook,
+    registerHookFromDefinition,
+    emitHook,
+    registerCommand,
+    invokeCommand,
+    getRegisteredCommands,
+    registerPromptTransformer,
+    applyPromptTransforms,
+    getPromptTransformerCount: () => promptTransformers.length,
+    getHookRegistrationSummary: () => {
+      return PLUGIN_HOOK_EVENTS.map((event) => `${event}:${hooksByEvent[event].length}`)
+    },
+  }
+}


### PR DESCRIPTION
## Summary\n- split renderer plugin runtime into focused modules: catalog store, discovery, loader, registries, contracts, and helpers\n- keep  as a backward-compatible facade for existing plugin APIs and app imports\n- preserve plugin lifecycle behavior while reducing cross-coupling between catalog sync and registration state\n\n## Validation\n- pnpm run lint:desktop\n- pnpm run typecheck\n- pnpm exec playwright test -c playwright.smoke.config.ts --workers=1\n\nCloses #98

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large refactor of core plugin discovery/loading and registration paths; behavior is intended to be preserved but regressions could affect plugin loading, hook execution, or command/transform ordering.
> 
> **Overview**
> Refactors the renderer plugin runtime from a single large `runtime.ts` into modular components: `runtime/contracts`, `helpers`, `discovery`, `loader`, `registries`, and a `catalog-store`.
> 
> `runtime.ts` now acts as a thin facade that delegates plugin discovery/sync, module loading/reconciliation, hook/command/transformer registration, and catalog snapshot subscription/updates to these new modules, while preserving the existing public API and built-in `/plugins` commands behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b769c4d37a8d6da3a51490cb197f62fc3ded155. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->