### PR TITLE
Refactor preload bridge with typed IPC helpers and shared channels

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,95 +1,79 @@
 import { contextBridge, ipcRenderer } from 'electron'
-import type { ElectronAPI } from '../shared/electron-api'
+import {
+  IPC_CHANNELS,
+  type ElectronAPI,
+  type Unsubscribe,
+} from '../shared/electron-api'
 import {
   PANEL_FOCUS_CHANNELS,
   panelIdFromFocusChannel,
   type PanelId,
 } from '../shared/panel-registry'
 
+type SubscriptionCallback<T> = T extends (callback: infer C) => Unsubscribe ? C : never
+
+function invokeFor<T extends (...args: never[]) => Promise<unknown>>(channel: string): T {
+  return ((...args: unknown[]) => {
+    return ipcRenderer.invoke(channel, ...args)
+  }) as unknown as T
+}
+
+function sendFor<T extends (...args: never[]) => void>(channel: string): T {
+  return ((...args: unknown[]) => {
+    ipcRenderer.send(channel, ...args)
+  }) as unknown as T
+}
+
+function subscribeFor<T extends (...args: never[]) => void>(
+  channel: string
+): (callback: T) => Unsubscribe {
+  return (callback) => {
+    const handler = (_event: Electron.IpcRendererEvent, ...args: unknown[]) => {
+      callback(...(args as Parameters<T>))
+    }
+    ipcRenderer.on(channel, handler)
+    return () => {
+      ipcRenderer.removeListener(channel, handler)
+    }
+  }
+}
+
 const electronAPI: ElectronAPI = {
   versions: {
     node: process.versions.node,
     chrome: process.versions.chrome,
-    electron: process.versions.electron
+    electron: process.versions.electron,
   },
   terminal: {
-    create: (options?: { cols?: number; rows?: number; cwd?: string }) =>
-      ipcRenderer.invoke('terminal:create', options) as Promise<{ id: string; cwd: string }>,
-
-    write: (id: string, data: string) =>
-      ipcRenderer.send('terminal:write', id, data),
-
-    resize: (id: string, cols: number, rows: number) =>
-      ipcRenderer.send('terminal:resize', id, cols, rows),
-
-    kill: (id: string) =>
-      ipcRenderer.invoke('terminal:kill', id) as Promise<void>,
-
-    onData: (callback: (id: string, data: string) => void) => {
-      const handler = (_event: Electron.IpcRendererEvent, id: string, data: string) =>
-        callback(id, data)
-      ipcRenderer.on('terminal:data', handler)
-      return () => { ipcRenderer.removeListener('terminal:data', handler) }
-    },
-
-    onExit: (callback: (id: string, exitCode: number, signal?: number) => void) => {
-      const handler = (
-        _event: Electron.IpcRendererEvent,
-        id: string,
-        exitCode: number,
-        signal?: number
-      ) => callback(id, exitCode, signal)
-      ipcRenderer.on('terminal:exit', handler)
-      return () => { ipcRenderer.removeListener('terminal:exit', handler) }
-    },
-
-    onClaudeStatus: (callback: (id: string, isRunning: boolean) => void) => {
-      const handler = (
-        _event: Electron.IpcRendererEvent,
-        id: string,
-        isRunning: boolean
-      ) => callback(id, isRunning)
-      ipcRenderer.on('terminal:claude-status', handler)
-      return () => { ipcRenderer.removeListener('terminal:claude-status', handler) }
-    }
+    create: invokeFor<ElectronAPI['terminal']['create']>(IPC_CHANNELS.terminal.create),
+    write: sendFor<ElectronAPI['terminal']['write']>(IPC_CHANNELS.terminal.write),
+    resize: sendFor<ElectronAPI['terminal']['resize']>(IPC_CHANNELS.terminal.resize),
+    kill: invokeFor<ElectronAPI['terminal']['kill']>(IPC_CHANNELS.terminal.kill),
+    onData: subscribeFor<SubscriptionCallback<ElectronAPI['terminal']['onData']>>(IPC_CHANNELS.terminal.data),
+    onExit: subscribeFor<SubscriptionCallback<ElectronAPI['terminal']['onExit']>>(IPC_CHANNELS.terminal.exit),
+    onClaudeStatus: subscribeFor<SubscriptionCallback<ElectronAPI['terminal']['onClaudeStatus']>>(
+      IPC_CHANNELS.terminal.claudeStatus
+    ),
   },
   settings: {
-    get: () => ipcRenderer.invoke('settings:get'),
-
-    set: (settings) => ipcRenderer.invoke('settings:set', settings),
-
-    selectDirectory: () => ipcRenderer.invoke('settings:selectDirectory'),
-
-    onOpenSettings: (callback: () => void) => {
-      const handler = () => callback()
-      ipcRenderer.on('menu:openSettings', handler)
-      return () => { ipcRenderer.removeListener('menu:openSettings', handler) }
-    },
-
-    onOpenHelp: (callback: () => void) => {
-      const handler = () => callback()
-      ipcRenderer.on('menu:openHelp', handler)
-      return () => { ipcRenderer.removeListener('menu:openHelp', handler) }
-    },
-
-    onNewTerminal: (callback: () => void) => {
-      const handler = () => callback()
-      ipcRenderer.on('menu:newTerminal', handler)
-      return () => { ipcRenderer.removeListener('menu:newTerminal', handler) }
-    },
-
-    onFocusChat: (callback: () => void) => {
-      const handler = () => callback()
-      ipcRenderer.on('menu:focusChat', handler)
-      return () => { ipcRenderer.removeListener('menu:focusChat', handler) }
-    },
-
-    onResetLayout: (callback: () => void) => {
-      const handler = () => callback()
-      ipcRenderer.on('menu:resetLayout', handler)
-      return () => { ipcRenderer.removeListener('menu:resetLayout', handler) }
-    },
-
+    get: invokeFor<ElectronAPI['settings']['get']>(IPC_CHANNELS.settings.get),
+    set: invokeFor<ElectronAPI['settings']['set']>(IPC_CHANNELS.settings.set),
+    selectDirectory: invokeFor<ElectronAPI['settings']['selectDirectory']>(IPC_CHANNELS.settings.selectDirectory),
+    onOpenSettings: subscribeFor<SubscriptionCallback<ElectronAPI['settings']['onOpenSettings']>>(
+      IPC_CHANNELS.settings.openSettings
+    ),
+    onOpenHelp: subscribeFor<SubscriptionCallback<ElectronAPI['settings']['onOpenHelp']>>(
+      IPC_CHANNELS.settings.openHelp
+    ),
+    onNewTerminal: subscribeFor<SubscriptionCallback<ElectronAPI['settings']['onNewTerminal']>>(
+      IPC_CHANNELS.settings.newTerminal
+    ),
+    onFocusChat: subscribeFor<SubscriptionCallback<ElectronAPI['settings']['onFocusChat']>>(
+      IPC_CHANNELS.settings.focusChat
+    ),
+    onResetLayout: subscribeFor<SubscriptionCallback<ElectronAPI['settings']['onResetLayout']>>(
+      IPC_CHANNELS.settings.resetLayout
+    ),
     onFocusPanel: (callback: (panelId: PanelId) => void) => {
       const handlers: Array<{ ch: (typeof PANEL_FOCUS_CHANNELS)[number]; handler: () => void }> = []
       for (const ch of PANEL_FOCUS_CHANNELS) {
@@ -107,194 +91,70 @@ const electronAPI: ElectronAPI = {
     },
   },
   fs: {
-    readDir: (dirPath: string, showHidden?: boolean) =>
-      ipcRenderer.invoke('fs:readDir', dirPath, showHidden) as Promise<Array<{
-        name: string; path: string; isDirectory: boolean; isSymlink: boolean; size: number; modified: number
-      }>>,
-
-    readFile: (filePath: string) =>
-      ipcRenderer.invoke('fs:readFile', filePath) as Promise<{
-        content: string; truncated: boolean; size: number
-      }>,
-
-    readImageDataUrl: (filePath: string) =>
-      ipcRenderer.invoke('fs:readImageDataUrl', filePath) as Promise<{
-        dataUrl: string; size: number; mimeType: string
-      }>,
-
-    search: (rootDir: string, query: string, maxResults?: number) =>
-      ipcRenderer.invoke('fs:search', rootDir, query, maxResults) as Promise<Array<{
-        path: string; name: string; isDirectory: boolean
-      }>>,
-
-    homeDir: () =>
-      ipcRenderer.invoke('fs:homeDir') as Promise<string>,
-
-    stat: (filePath: string) =>
-      ipcRenderer.invoke('fs:stat', filePath) as Promise<{
-        isDirectory: boolean; isFile: boolean; size: number; modified: number
-      }>,
-
-    writeFile: (filePath: string, content: string) =>
-      ipcRenderer.invoke('fs:writeFile', filePath, content) as Promise<void>,
-
-    openFolderDialog: () =>
-      ipcRenderer.invoke('fs:openFolderDialog') as Promise<string | null>,
-
-    onOpenFolder: (callback: (folderPath: string) => void) => {
-      const handler = (_event: Electron.IpcRendererEvent, folderPath: string) =>
-        callback(folderPath)
-      ipcRenderer.on('fs:openFolder', handler)
-      return () => { ipcRenderer.removeListener('fs:openFolder', handler) }
-    },
-
-    rename: (oldPath: string, newName: string) =>
-      ipcRenderer.invoke('fs:rename', oldPath, newName) as Promise<{ newPath: string }>,
-
-    delete: (filePath: string) =>
-      ipcRenderer.invoke('fs:delete', filePath) as Promise<void>,
-
-    revealInFinder: (filePath: string) =>
-      ipcRenderer.invoke('fs:revealInFinder', filePath) as Promise<void>,
-
-    openInTerminal: (dirPath: string) =>
-      ipcRenderer.invoke('fs:openInTerminal', dirPath) as Promise<void>,
+    readDir: invokeFor<ElectronAPI['fs']['readDir']>(IPC_CHANNELS.fs.readDir),
+    readFile: invokeFor<ElectronAPI['fs']['readFile']>(IPC_CHANNELS.fs.readFile),
+    readImageDataUrl: invokeFor<ElectronAPI['fs']['readImageDataUrl']>(IPC_CHANNELS.fs.readImageDataUrl),
+    search: invokeFor<ElectronAPI['fs']['search']>(IPC_CHANNELS.fs.search),
+    homeDir: invokeFor<ElectronAPI['fs']['homeDir']>(IPC_CHANNELS.fs.homeDir),
+    stat: invokeFor<ElectronAPI['fs']['stat']>(IPC_CHANNELS.fs.stat),
+    writeFile: invokeFor<ElectronAPI['fs']['writeFile']>(IPC_CHANNELS.fs.writeFile),
+    openFolderDialog: invokeFor<ElectronAPI['fs']['openFolderDialog']>(IPC_CHANNELS.fs.openFolderDialog),
+    onOpenFolder: subscribeFor<SubscriptionCallback<ElectronAPI['fs']['onOpenFolder']>>(IPC_CHANNELS.fs.openFolder),
+    rename: invokeFor<ElectronAPI['fs']['rename']>(IPC_CHANNELS.fs.rename),
+    delete: invokeFor<ElectronAPI['fs']['delete']>(IPC_CHANNELS.fs.delete),
+    revealInFinder: invokeFor<ElectronAPI['fs']['revealInFinder']>(IPC_CHANNELS.fs.revealInFinder),
+    openInTerminal: invokeFor<ElectronAPI['fs']['openInTerminal']>(IPC_CHANNELS.fs.openInTerminal),
   },
   lsp: {
-    start: (languageId: string) =>
-      ipcRenderer.invoke('lsp:start', languageId) as Promise<{
-        serverId: string; languages: string[]
-      } | null>,
-
-    send: (serverId: string, message: unknown) =>
-      ipcRenderer.invoke('lsp:send', serverId, message) as Promise<boolean>,
-
-    stop: (serverId: string) =>
-      ipcRenderer.invoke('lsp:stop', serverId) as Promise<boolean>,
-
-    languages: () =>
-      ipcRenderer.invoke('lsp:languages') as Promise<Array<{
-        name: string; languages: string[]; active: boolean
-      }>>,
-
-    onMessage: (callback) => {
-      const handler = (
-        _event: Electron.IpcRendererEvent,
-        data: { serverId: string; message: unknown }
-      ): void => {
-        callback(data)
-      }
-      ipcRenderer.on('lsp:message', handler)
-      return () => { ipcRenderer.removeListener('lsp:message', handler) }
-    },
+    start: invokeFor<ElectronAPI['lsp']['start']>(IPC_CHANNELS.lsp.start),
+    send: invokeFor<ElectronAPI['lsp']['send']>(IPC_CHANNELS.lsp.send),
+    stop: invokeFor<ElectronAPI['lsp']['stop']>(IPC_CHANNELS.lsp.stop),
+    languages: invokeFor<ElectronAPI['lsp']['languages']>(IPC_CHANNELS.lsp.languages),
+    onMessage: subscribeFor<SubscriptionCallback<ElectronAPI['lsp']['onMessage']>>(IPC_CHANNELS.lsp.message),
   },
   claude: {
-    start: (options) =>
-      ipcRenderer.invoke('claude:start', options) as Promise<{ sessionId: string }>,
-
-    stop: (sessionId: string) =>
-      ipcRenderer.invoke('claude:stop', sessionId) as Promise<void>,
-
-    isAvailable: () =>
-      ipcRenderer.invoke('claude:isAvailable') as Promise<{
-        available: boolean
-        binaryPath: string | null
-        version: string | null
-        error?: string
-      }>,
-
-    onEvent: (callback) => {
-      const handler = (
-        _event: Electron.IpcRendererEvent,
-        claudeEvent: unknown
-      ) => callback(claudeEvent as Parameters<typeof callback>[0])
-      ipcRenderer.on('claude:event', handler)
-      return () => { ipcRenderer.removeListener('claude:event', handler) }
-    }
+    start: invokeFor<ElectronAPI['claude']['start']>(IPC_CHANNELS.claude.start),
+    stop: invokeFor<ElectronAPI['claude']['stop']>(IPC_CHANNELS.claude.stop),
+    isAvailable: invokeFor<ElectronAPI['claude']['isAvailable']>(IPC_CHANNELS.claude.isAvailable),
+    onEvent: subscribeFor<SubscriptionCallback<ElectronAPI['claude']['onEvent']>>(IPC_CHANNELS.claude.event),
   },
   agent: {
-    generateMeta: (prompt: string) =>
-      ipcRenderer.invoke('agent:generateMeta', prompt) as Promise<{ name: string; taskDescription: string }>,
+    generateMeta: invokeFor<ElectronAPI['agent']['generateMeta']>(IPC_CHANNELS.agent.generateMeta),
   },
   chat: {
-    popout: (sessionId: string) =>
-      ipcRenderer.invoke('chat:popout', sessionId) as Promise<void>,
-
-    onReturned: (callback: (sessionId: string) => void) => {
-      const handler = (_event: Electron.IpcRendererEvent, sessionId: string) =>
-        callback(sessionId)
-      ipcRenderer.on('chat:returned', handler)
-      return () => { ipcRenderer.removeListener('chat:returned', handler) }
-    },
+    popout: invokeFor<ElectronAPI['chat']['popout']>(IPC_CHANNELS.chat.popout),
+    onReturned: subscribeFor<SubscriptionCallback<ElectronAPI['chat']['onReturned']>>(IPC_CHANNELS.chat.returned),
   },
   memories: {
-    addChatMessage: (opts) => ipcRenderer.invoke('memories:addChatMessage', opts) as Promise<void>,
-
-    getChatHistory: (scopeId: string, limit?: number) =>
-      ipcRenderer.invoke('memories:getChatHistory', scopeId, limit) as Promise<Array<{
-        id: string; content: string; role: string; timestamp: string; category: string
-      }>>,
-
-    isReady: () =>
-      ipcRenderer.invoke('memories:isReady') as Promise<boolean>,
+    addChatMessage: invokeFor<ElectronAPI['memories']['addChatMessage']>(IPC_CHANNELS.memories.addChatMessage),
+    getChatHistory: invokeFor<ElectronAPI['memories']['getChatHistory']>(IPC_CHANNELS.memories.getChatHistory),
+    isReady: invokeFor<ElectronAPI['memories']['isReady']>(IPC_CHANNELS.memories.isReady),
   },
   diagnostics: {
-    logRenderer: (level, event, payload) =>
-      ipcRenderer.invoke('diagnostics:logRenderer', { level, event, payload }) as Promise<void>,
-
-    getLogPath: () =>
-      ipcRenderer.invoke('diagnostics:getLogPath') as Promise<string>,
+    logRenderer: invokeFor<ElectronAPI['diagnostics']['logRenderer']>(IPC_CHANNELS.diagnostics.logRenderer),
+    getLogPath: invokeFor<ElectronAPI['diagnostics']['getLogPath']>(IPC_CHANNELS.diagnostics.getLogPath),
   },
   context: {
-    getWorkspaceSnapshot: (directory: string) =>
-      ipcRenderer.invoke('context:getWorkspaceSnapshot', directory),
+    getWorkspaceSnapshot: invokeFor<ElectronAPI['context']['getWorkspaceSnapshot']>(
+      IPC_CHANNELS.context.getWorkspaceSnapshot
+    ),
   },
   scheduler: {
-    list: () =>
-      ipcRenderer.invoke('scheduler:list'),
-
-    upsert: (task) =>
-      ipcRenderer.invoke('scheduler:upsert', task),
-
-    delete: (taskId: string) =>
-      ipcRenderer.invoke('scheduler:delete', taskId) as Promise<void>,
-
-    runNow: (taskId: string) =>
-      ipcRenderer.invoke('scheduler:runNow', taskId),
-
-    debugRuntimeSize: () =>
-      ipcRenderer.invoke('scheduler:debugRuntimeSize') as Promise<number>,
-
-    onUpdated: (callback: () => void) => {
-      const handler = () => callback()
-      ipcRenderer.on('scheduler:updated', handler)
-      return () => { ipcRenderer.removeListener('scheduler:updated', handler) }
-    },
+    list: invokeFor<ElectronAPI['scheduler']['list']>(IPC_CHANNELS.scheduler.list),
+    upsert: invokeFor<ElectronAPI['scheduler']['upsert']>(IPC_CHANNELS.scheduler.upsert),
+    delete: invokeFor<ElectronAPI['scheduler']['delete']>(IPC_CHANNELS.scheduler.delete),
+    runNow: invokeFor<ElectronAPI['scheduler']['runNow']>(IPC_CHANNELS.scheduler.runNow),
+    debugRuntimeSize: invokeFor<ElectronAPI['scheduler']['debugRuntimeSize']>(IPC_CHANNELS.scheduler.debugRuntimeSize),
+    onUpdated: subscribeFor<SubscriptionCallback<ElectronAPI['scheduler']['onUpdated']>>(IPC_CHANNELS.scheduler.updated),
   },
   todoRunner: {
-    list: () =>
-      ipcRenderer.invoke('todoRunner:list'),
-
-    upsert: (job) =>
-      ipcRenderer.invoke('todoRunner:upsert', job),
-
-    delete: (jobId: string) =>
-      ipcRenderer.invoke('todoRunner:delete', jobId) as Promise<void>,
-
-    start: (jobId: string) =>
-      ipcRenderer.invoke('todoRunner:start', jobId),
-
-    pause: (jobId: string) =>
-      ipcRenderer.invoke('todoRunner:pause', jobId),
-
-    reset: (jobId: string) =>
-      ipcRenderer.invoke('todoRunner:reset', jobId),
-
-    onUpdated: (callback: () => void) => {
-      const handler = () => callback()
-      ipcRenderer.on('todoRunner:updated', handler)
-      return () => { ipcRenderer.removeListener('todoRunner:updated', handler) }
-    },
+    list: invokeFor<ElectronAPI['todoRunner']['list']>(IPC_CHANNELS.todoRunner.list),
+    upsert: invokeFor<ElectronAPI['todoRunner']['upsert']>(IPC_CHANNELS.todoRunner.upsert),
+    delete: invokeFor<ElectronAPI['todoRunner']['delete']>(IPC_CHANNELS.todoRunner.delete),
+    start: invokeFor<ElectronAPI['todoRunner']['start']>(IPC_CHANNELS.todoRunner.start),
+    pause: invokeFor<ElectronAPI['todoRunner']['pause']>(IPC_CHANNELS.todoRunner.pause),
+    reset: invokeFor<ElectronAPI['todoRunner']['reset']>(IPC_CHANNELS.todoRunner.reset),
+    onUpdated: subscribeFor<SubscriptionCallback<ElectronAPI['todoRunner']['onUpdated']>>(IPC_CHANNELS.todoRunner.updated),
   },
 }
 

--- a/src/shared/electron-api.ts
+++ b/src/shared/electron-api.ts
@@ -12,6 +12,92 @@ import type { PanelId } from './panel-registry'
 
 export type Unsubscribe = () => void
 
+export const IPC_CHANNELS = {
+  terminal: {
+    create: 'terminal:create',
+    write: 'terminal:write',
+    resize: 'terminal:resize',
+    kill: 'terminal:kill',
+    data: 'terminal:data',
+    exit: 'terminal:exit',
+    claudeStatus: 'terminal:claude-status',
+  },
+  settings: {
+    get: 'settings:get',
+    set: 'settings:set',
+    selectDirectory: 'settings:selectDirectory',
+    openSettings: 'menu:openSettings',
+    openHelp: 'menu:openHelp',
+    newTerminal: 'menu:newTerminal',
+    focusChat: 'menu:focusChat',
+    resetLayout: 'menu:resetLayout',
+  },
+  fs: {
+    readDir: 'fs:readDir',
+    readFile: 'fs:readFile',
+    readImageDataUrl: 'fs:readImageDataUrl',
+    search: 'fs:search',
+    homeDir: 'fs:homeDir',
+    stat: 'fs:stat',
+    writeFile: 'fs:writeFile',
+    openFolderDialog: 'fs:openFolderDialog',
+    openFolder: 'fs:openFolder',
+    rename: 'fs:rename',
+    delete: 'fs:delete',
+    revealInFinder: 'fs:revealInFinder',
+    openInTerminal: 'fs:openInTerminal',
+  },
+  lsp: {
+    start: 'lsp:start',
+    send: 'lsp:send',
+    stop: 'lsp:stop',
+    languages: 'lsp:languages',
+    message: 'lsp:message',
+  },
+  claude: {
+    start: 'claude:start',
+    stop: 'claude:stop',
+    isAvailable: 'claude:isAvailable',
+    event: 'claude:event',
+  },
+  agent: {
+    generateMeta: 'agent:generateMeta',
+  },
+  chat: {
+    popout: 'chat:popout',
+    returned: 'chat:returned',
+  },
+  memories: {
+    addChatMessage: 'memories:addChatMessage',
+    getChatHistory: 'memories:getChatHistory',
+    isReady: 'memories:isReady',
+  },
+  diagnostics: {
+    logRenderer: 'diagnostics:logRenderer',
+    getLogPath: 'diagnostics:getLogPath',
+  },
+  context: {
+    getWorkspaceSnapshot: 'context:getWorkspaceSnapshot',
+  },
+  scheduler: {
+    list: 'scheduler:list',
+    upsert: 'scheduler:upsert',
+    delete: 'scheduler:delete',
+    runNow: 'scheduler:runNow',
+    debugRuntimeSize: 'scheduler:debugRuntimeSize',
+    updated: 'scheduler:updated',
+  },
+  todoRunner: {
+    list: 'todoRunner:list',
+    upsert: 'todoRunner:upsert',
+    delete: 'todoRunner:delete',
+    start: 'todoRunner:start',
+    pause: 'todoRunner:pause',
+    reset: 'todoRunner:reset',
+    updated: 'todoRunner:updated',
+  },
+} as const
+
 export interface FsEntry {
   name: string
   path: string


### PR DESCRIPTION
## Summary
- add centralized IPC channel constants in src/shared/electron-api.ts
- refactor src/preload/index.ts to use typed invokeFor/sendFor/subscribeFor helper factories
- standardize listener setup/cleanup patterns while preserving the ElectronAPI contract surface

## Validation
- pnpm run lint:desktop
- pnpm run typecheck
- pnpm exec playwright test -c playwright.smoke.config.ts --workers=1

Closes #100

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly a refactor of renderer↔main IPC wiring (channel constants + helper wrappers) with minimal behavioral change; main risk is mismatched channel names or subtly altered listener argument forwarding.
> 
> **Overview**
> Refactors the Electron preload bridge to reduce repetitive IPC boilerplate by introducing typed helper factories (`invokeFor`, `sendFor`, `subscribeFor`) and using them to wire the entire `ElectronAPI` surface.
> 
> Centralizes all IPC channel strings into a shared `IPC_CHANNELS` constant in `src/shared/electron-api.ts`, replacing scattered hardcoded channel names in the preload layer while keeping the exposed API contract the same (including standardized subscribe/unsubscribe listener setup).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd03b2595947c7c1fa304e716f7bdaab6ae3685c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->