### PR TITLE
Add scheduler catch-up backfill window for missed cron minutes

### DIFF
--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -332,6 +332,8 @@ export function SettingsPanel() {
       lastError: null,
       lastDurationMs: null,
       lastRunTrigger: null,
+      lastScheduledMinuteKey: null,
+      lastBackfillMinutes: null,
       isDraft: true,
     }
     setScheduleDrafts((prev) => [...prev, task])

--- a/src/renderer/components/settings/SchedulerTab.tsx
+++ b/src/renderer/components/settings/SchedulerTab.tsx
@@ -221,6 +221,14 @@ export function SchedulerTab({
                 Last run: {formatDateTime(task.lastRunAt)}
                 {task.lastDurationMs != null ? ` (${formatDuration(task.lastDurationMs)})` : ''}
               </div>
+              {task.lastScheduledMinuteKey && (
+                <div>
+                  Last scheduled minute: {task.lastScheduledMinuteKey}
+                  {task.lastBackfillMinutes != null && task.lastBackfillMinutes > 0
+                    ? ` (backfill ${task.lastBackfillMinutes}m)`
+                    : ''}
+                </div>
+              )}
               {task.lastError && (
                 <div style={{ color: '#c45050' }}>Last error: {task.lastError}</div>
               )}

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -245,6 +245,8 @@ export interface SchedulerTask {
   lastError: string | null
   lastDurationMs: number | null
   lastRunTrigger: SchedulerRunTrigger | null
+  lastScheduledMinuteKey: string | null
+  lastBackfillMinutes: number | null
 }
 
 export interface TodoRunnerJobInput {


### PR DESCRIPTION
## Summary\n- add bounded cron backfill window scanning between successful scheduler ticks\n- queue per-task missed cron minutes and dispatch sequentially to avoid duplicates\n- attach scheduled-minute/backfill metadata to runtime, logs, and scheduler UI\n\nCloses #115

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core scheduler tick/run dispatch to scan a multi-minute window and queue/dispatch runs, which could affect cron execution order and frequency if there are edge cases in deduping or window clamping; mitigated by bounded window and sequential per-task dispatch.
> 
> **Overview**
> Adds a bounded *cron catch-up/backfill* mechanism so missed minutes between successful scheduler ticks are scanned and queued, then dispatched sequentially per task to avoid duplicate/overlapping runs.
> 
> Introduces `AGENT_SPACE_SCHEDULER_BACKFILL_WINDOW_MINUTES` (default 15, clamped to 24h), tracks `lastSuccessfulSchedulerTickAt`, and logs when the backfill window is scanned/clamped.
> 
> Extends scheduler runtime/UI metadata with `lastScheduledMinuteKey` and `lastBackfillMinutes`, and includes scheduled/backfill context in run prompts and diagnostic events; clears pending queues on task disable/cron change/delete/cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b75bfe314271b24f87e2e890f02bbbf67c0494e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->