### PR TITLE
Fix todo-runner async spawn concurrency race

### DIFF
--- a/tests/smoke/todo-runner-concurrency.spec.ts
+++ b/tests/smoke/todo-runner-concurrency.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '@playwright/test'
+import { __testOnlyComputeTodoRunnerAvailableSlots } from '../../src/main/todo-runner'
+
+test('slow-spawn reservation consumes slot before process bookkeeping updates', () => {
+  const maxConcurrentJobs = 1
+
+  // Initial state: no running jobs and no pending starts.
+  expect(__testOnlyComputeTodoRunnerAvailableSlots(maxConcurrentJobs, 0, 0)).toBe(1)
+
+  // Simulated slow spawn: launch is reserved but process has not reached onSpawned yet.
+  expect(__testOnlyComputeTodoRunnerAvailableSlots(maxConcurrentJobs, 0, 1)).toBe(0)
+
+  // After spawn callback moves reservation into the running map, capacity remains full.
+  expect(__testOnlyComputeTodoRunnerAvailableSlots(maxConcurrentJobs, 1, 0)).toBe(0)
+
+  // Capacity returns only after the running todo exits.
+  expect(__testOnlyComputeTodoRunnerAvailableSlots(maxConcurrentJobs, 0, 0)).toBe(1)
+})
+
+test('available slots are clamped and count running plus pending starts', () => {
+  expect(__testOnlyComputeTodoRunnerAvailableSlots(3, 0, 0)).toBe(3)
+  expect(__testOnlyComputeTodoRunnerAvailableSlots(3, 1, 1)).toBe(1)
+  expect(__testOnlyComputeTodoRunnerAvailableSlots(3, 2, 1)).toBe(0)
+  expect(__testOnlyComputeTodoRunnerAvailableSlots(2, 4, 4)).toBe(0)
+})


### PR DESCRIPTION
## Summary\n- reserve pending-start capacity before launching todo runs from the scheduler tick\n- count  when computing available concurrency slots\n- add slow-spawn concurrency tests for slot accounting behavior\n\nCloses #116

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches scheduling/concurrency bookkeeping and adds new state transitions; bugs could stall jobs or miscount capacity, but changes are localized and covered by new tests.
> 
> **Overview**
> Fixes a concurrency race in the todo runner where *slow process spawns* could exceed `AGENT_SPACE_TODO_RUNNER_MAX_CONCURRENT_JOBS`.
> 
> The scheduler now reserves a per-job **pending start** slot (`pendingStartByJobId`) before launching `runTodo`, counts pending starts when computing available slots, and prevents editing/starting a job while it is pending-start. Reservation is released on spawn, early exits, and cleanup.
> 
> Adds smoke tests around slot accounting via `__testOnlyComputeTodoRunnerAvailableSlots` to lock in the pending-start behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec653485deb5928118df0caa47e6c813446272d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->