### PR TITLE
Track pending-start todo jobs in dispatch eligibility

### DIFF
--- a/tests/smoke/todo-runner-concurrency.spec.ts
+++ b/tests/smoke/todo-runner-concurrency.spec.ts
@@ -3,6 +3,7 @@ import {
   __testOnlyCollectStaleRunningTodoIndices,
   __testOnlyComputeTodoRunnerAvailableSlots,
   __testOnlyFindNextRunnableTodoIndex,
+  __testOnlyIsTodoJobDispatchEligible,
 } from '../../src/main/todo-runner'
 
 test('slow-spawn reservation consumes slot before process bookkeeping updates', () => {
@@ -26,6 +27,13 @@ test('available slots are clamped and count running plus pending starts', () => 
   expect(__testOnlyComputeTodoRunnerAvailableSlots(3, 1, 1)).toBe(1)
   expect(__testOnlyComputeTodoRunnerAvailableSlots(3, 2, 1)).toBe(0)
   expect(__testOnlyComputeTodoRunnerAvailableSlots(2, 4, 4)).toBe(0)
+})
+
+test('dispatch eligibility excludes both running and pending-start states', () => {
+  expect(__testOnlyIsTodoJobDispatchEligible(false, false)).toBe(true)
+  expect(__testOnlyIsTodoJobDispatchEligible(true, false)).toBe(false)
+  expect(__testOnlyIsTodoJobDispatchEligible(false, true)).toBe(false)
+  expect(__testOnlyIsTodoJobDispatchEligible(true, true)).toBe(false)
 })
 
 test('candidate selection is pure and does not mutate running todos', () => {


### PR DESCRIPTION
## Summary
- centralize todo dispatch eligibility into a single running/pending-start gate
- apply the same gate for edit/start/tick launch paths
- add tests covering timing-independent pending-start/running eligibility rules

Closes #118

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor that unifies existing running/pending-start checks and adds coverage; low risk beyond possible behavior change in edge-case dispatch timing.
> 
> **Overview**
> Centralizes todo job dispatch gating into a single eligibility check that treats both *running* and *pending-start* jobs as ineligible.
> 
> Applies this gate consistently across pending-start reservation, job edits (blocking todo list changes), manual starts, and the tick-based scheduler scan, reducing race windows during slow spawns. Adds a smoke test covering the eligibility truth table.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4488e9cfa9770fd67f18a7625fd69aa07c82c3b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->