### PR TITLE
refactor: scope claude event delivery by session subscribers

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -115,6 +115,8 @@ const electronAPI: ElectronAPI = {
   claude: {
     start: invokeFor<ElectronAPI['claude']['start']>(IPC_CHANNELS.claude.start),
     stop: invokeFor<ElectronAPI['claude']['stop']>(IPC_CHANNELS.claude.stop),
+    observeSession: invokeFor<ElectronAPI['claude']['observeSession']>(IPC_CHANNELS.claude.observeSession),
+    unobserveSession: invokeFor<ElectronAPI['claude']['unobserveSession']>(IPC_CHANNELS.claude.unobserveSession),
     isAvailable: invokeFor<ElectronAPI['claude']['isAvailable']>(IPC_CHANNELS.claude.isAvailable),
     onEvent: subscribeFor<SubscriptionCallback<ElectronAPI['claude']['onEvent']>>(IPC_CHANNELS.claude.event),
   },

--- a/src/renderer/components/chat/ChatPanel.tsx
+++ b/src/renderer/components/chat/ChatPanel.tsx
@@ -212,6 +212,18 @@ export function ChatPanel({ chatSessionId }: ChatPanelProps) {
     setClaudeSessionId(sessionId)
   }, [])
 
+  useEffect(() => {
+    if (!claudeSessionId) return
+    void window.electronAPI.claude.observeSession(claudeSessionId).catch((error) => {
+      console.warn('[ChatPanel] Failed to observe Claude session:', error)
+    })
+    return () => {
+      void window.electronAPI.claude.unobserveSession(claudeSessionId).catch((error) => {
+        console.warn('[ChatPanel] Failed to unobserve Claude session:', error)
+      })
+    }
+  }, [claudeSessionId])
+
   const workingDir = chatSession ? chatSession.workingDirectory : fallbackWorkingDir
   const isDirectoryCustom = chatSession ? chatSession.directoryMode === 'custom' : false
   const hasStartedConversation = Boolean(chatSession?.agentId)

--- a/src/shared/electron-api.ts
+++ b/src/shared/electron-api.ts
@@ -57,6 +57,8 @@ export const IPC_CHANNELS = {
   claude: {
     start: 'claude:start',
     stop: 'claude:stop',
+    observeSession: 'claude:observeSession',
+    unobserveSession: 'claude:unobserveSession',
     isAvailable: 'claude:isAvailable',
     event: 'claude:event',
   },
@@ -215,6 +217,8 @@ export interface ElectronAPI {
   claude: {
     start: (options: ClaudeSessionOptions) => Promise<{ sessionId: string }>
     stop: (sessionId: string) => Promise<void>
+    observeSession: (sessionId: string) => Promise<void>
+    unobserveSession: (sessionId: string) => Promise<void>
     isAvailable: () => Promise<{ available: boolean; binaryPath: string | null; version: string | null; error?: string }>
     onEvent: (callback: (event: ClaudeEvent) => void) => Unsubscribe
   }

--- a/tests/smoke/claude-event-routing.spec.ts
+++ b/tests/smoke/claude-event-routing.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@playwright/test'
+import { __testOnlyResolveClaudeEventTargetIds } from '../../src/main/claude-session'
+
+test('routes claude events to owning window when no extra observers are registered', () => {
+  const targets = __testOnlyResolveClaudeEventTargetIds(42, [])
+  expect(targets).toEqual([42])
+})
+
+test('routes claude events to owner plus observers without duplicate ids', () => {
+  const targets = __testOnlyResolveClaudeEventTargetIds(42, [42, 43, 44, 43])
+  expect(targets).toEqual([42, 43, 44])
+})
+
+test('supports observer-only delivery for externally observed sessions', () => {
+  const targets = __testOnlyResolveClaudeEventTargetIds(null, [77, 78])
+  expect(targets).toEqual([77, 78])
+})


### PR DESCRIPTION
## Summary
- route Claude session events only to owner and explicit observers instead of all windows
- add observe/unobserve IPC plumbing from main/preload/shared API and ChatPanel observer lifecycle hooks
- add smoke tests for owner-only, owner+observer, and observer-only routing behavior

Closes #121

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the routing of `claude:event` IPC messages from broadcast-to-all-windows to targeted delivery, which can break chat/popout UX if observer registration is missed or cleanup is wrong.
> 
> **Overview**
> Claude session events are no longer broadcast to every window; `emitEvent` now targets only the session’s owning `webContents` plus any explicitly registered observers, with a fallback broadcast only when no targets are tracked.
> 
> This threads an `ownerWebContentsId` through session startup, adds `claude:observeSession`/`claude:unobserveSession` IPC + preload/shared API wiring, and updates `ChatPanel` to automatically observe/unobserve its active session. It also adds a small smoke test for the target-id resolution/deduping helper used by the new routing logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48950416a1db30802ec7b3b71d64300cbbb50bf9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->