### PR TITLE
refactor: await managed child-process shutdown before app quit

### DIFF
--- a/tests/smoke/process-shutdown.spec.ts
+++ b/tests/smoke/process-shutdown.spec.ts
@@ -1,0 +1,80 @@
+import { spawn, type ChildProcess } from 'child_process'
+import { once } from 'events'
+import { expect, test } from '@playwright/test'
+import { terminateManagedProcess } from '../../src/main/process-runner'
+
+async function forceKillIfRunning(childProcess: ChildProcess): Promise<void> {
+  if (childProcess.exitCode !== null || childProcess.signalCode !== null) return
+  try {
+    childProcess.kill('SIGKILL')
+  } catch {
+    // Process may already be gone.
+  }
+  try {
+    await once(childProcess, 'exit')
+  } catch {
+    // Ignore post-kill wait failures in test cleanup.
+  }
+}
+
+test('termination helper is a no-op for already exited processes', async () => {
+  const childProcess = spawn(process.execPath, ['-e', 'process.exit(0)'], {
+    stdio: 'ignore',
+  })
+  await once(childProcess, 'exit')
+
+  const result = await terminateManagedProcess({
+    process: childProcess,
+    sigtermTimeoutMs: 100,
+  })
+
+  expect(result.escalatedToSigkill).toBe(false)
+  expect(result.timedOut).toBe(false)
+})
+
+test('termination helper shuts down process via SIGTERM before escalation deadline', async () => {
+  const childProcess = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+    stdio: 'ignore',
+  })
+
+  try {
+    const result = await terminateManagedProcess({
+      process: childProcess,
+      sigtermTimeoutMs: 1_000,
+      sigkillTimeoutMs: 500,
+    })
+
+    expect(result.escalatedToSigkill).toBe(false)
+    expect(result.timedOut).toBe(false)
+    expect(result.exitCode === 0 || result.signalCode === 'SIGTERM').toBe(true)
+  } finally {
+    await forceKillIfRunning(childProcess)
+  }
+})
+
+test('termination helper escalates to SIGKILL after SIGTERM deadline', async () => {
+  const childProcess = spawn(
+    process.execPath,
+    ['-e', 'process.on("SIGTERM", () => {}); setInterval(() => {}, 1000)'],
+    {
+      stdio: 'ignore',
+    }
+  )
+
+  try {
+    // Give the child time to install its SIGTERM handler deterministically.
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    const result = await terminateManagedProcess({
+      process: childProcess,
+      sigtermTimeoutMs: 200,
+      sigkillTimeoutMs: 1_000,
+    })
+
+    expect(result.escalatedToSigkill).toBe(true)
+    expect(result.timedOut).toBe(false)
+    expect(result.signalCode).toBe('SIGKILL')
+  } finally {
+    await forceKillIfRunning(childProcess)
+  }
+})


### PR DESCRIPTION
## Summary
- add a shared managed-process termination helper that awaits exit after SIGTERM with bounded SIGKILL escalation
- convert scheduler, todo-runner, and claude-session cleanup paths to async shutdown that awaits child exits and logs outcomes
- coordinate app `before-quit` lifecycle to run ordered async shutdown steps before allowing quit
- add smoke coverage for normal SIGTERM shutdown and SIGKILL escalation behavior

Closes #122

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches app lifecycle and process termination paths, so bugs could cause hangs or incomplete shutdown, but the logic is bounded by timeouts and has added test coverage.
> 
> **Overview**
> Improves shutdown reliability by introducing `terminateManagedProcess` to send `SIGTERM`, await child exit, and *escalate to `SIGKILL`* with bounded timeouts, returning structured exit/timeout telemetry.
> 
> Updates `claude-session`, `scheduler`, and `todo-runner` cleanup paths to be async and to await managed child-process termination, with new start/completed logging (including exit code/signal, escalation, and duration).
> 
> Adds a coordinated async `before-quit` flow in `main/index.ts` that prevents immediate quit, runs ordered shutdown steps, and only then calls `app.quit()`. Adds smoke tests covering no-op, SIGTERM success, and SIGKILL escalation behavior for the new helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 712820ea2ba2f25721e0604b9a5ae74c5b2aaf8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->