### PR TITLE
docs: adopt MIT license and update repository references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,5 +28,5 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - Improved office scene styling and parity between desktop and web interactions.
 
-[Unreleased]: https://github.com/webrenew/agent-space/compare/v1.1.0...HEAD
-[1.1.0]: https://github.com/webrenew/agent-space/releases/tag/v1.1.0
+[Unreleased]: https://github.com/webrenew/agent-observer/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/webrenew/agent-observer/releases/tag/v1.1.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,15 +1,21 @@
-ISC License
+MIT License
 
 Copyright (c) 2026 Webrenew
 
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
-AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
-LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
-OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-PERFORMANCE OF THIS SOFTWARE.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -73,4 +73,4 @@ pnpm -C web dev
 
 ## License
 
-ISC License. See [`LICENSE`](./LICENSE).
+MIT License. See [`LICENSE`](./LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ Please do not report security vulnerabilities in public GitHub issues.
 Use one of the following private channels:
 
 1. GitHub Security Advisories:
-   [https://github.com/webrenew/agent-space/security/advisories/new](https://github.com/webrenew/agent-space/security/advisories/new)
+   [https://github.com/webrenew/agent-observer/security/advisories/new](https://github.com/webrenew/agent-observer/security/advisories/new)
 2. Email: `opensource@webrenew.com`
 
 Please include:

--- a/package.json
+++ b/package.json
@@ -19,16 +19,16 @@
   },
   "keywords": [],
   "author": "Webrenew",
-  "license": "ISC",
+  "license": "MIT",
   "packageManager": "pnpm@10.12.4",
   "repository": {
     "type": "git",
-    "url": "https://github.com/webrenew/agent-space.git"
+    "url": "https://github.com/webrenew/agent-observer.git"
   },
   "bugs": {
-    "url": "https://github.com/webrenew/agent-space/issues"
+    "url": "https://github.com/webrenew/agent-observer/issues"
   },
-  "homepage": "https://github.com/webrenew/agent-space#readme",
+  "homepage": "https://github.com/webrenew/agent-observer#readme",
   "engines": {
     "node": ">=22 <23",
     "pnpm": ">=10.12.4"

--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,7 @@
   "name": "agent-observer-web",
   "version": "0.1.0",
   "private": true,
+  "license": "MIT",
   "engines": {
     "node": ">=22 <23",
     "pnpm": ">=10.12.4"

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -6,8 +6,8 @@
 
 - Website: /
 - Installer: /download
-- Repository: https://github.com/webrenew/agent-space
-- Releases: https://github.com/webrenew/agent-space/releases/latest
+- Repository: https://github.com/webrenew/agent-observer
+- Releases: https://github.com/webrenew/agent-observer/releases/latest
 
 ## Key pages
 

--- a/web/src/lib/downloads.ts
+++ b/web/src/lib/downloads.ts
@@ -4,7 +4,7 @@ export const AGENT_SPACE_REPO_URL = SITE_REPO_URL;
 export const AGENT_SPACE_RELEASES_URL = SITE_RELEASES_URL;
 export const AGENT_SPACE_INSTALLER_URL = "/download";
 export const AGENT_SPACE_RELEASES_API_URL =
-  "https://api.github.com/repos/webrenew/agent-space/releases/latest";
+  "https://api.github.com/repos/webrenew/agent-observer/releases/latest";
 
 export interface GitHubReleaseAsset {
   name: string;

--- a/web/src/lib/site.ts
+++ b/web/src/lib/site.ts
@@ -19,6 +19,6 @@ export const SITE_NAME = "Agent Observer";
 export const SITE_TITLE = "Agent Observer — Mission Control for Your AI Agents";
 export const SITE_DESCRIPTION =
   "Observe, debug, and manage every AI agent across your tools. Real-time dashboards, traces, and alerts in one workspace.";
-export const SITE_REPO_URL = "https://github.com/webrenew/agent-space";
+export const SITE_REPO_URL = "https://github.com/webrenew/agent-observer";
 export const SITE_RELEASES_URL = `${SITE_REPO_URL}/releases/latest`;
 export const SITE_OG_IMAGE = "/opengraph.png";


### PR DESCRIPTION
## Summary
- replace the repository license from ISC to MIT in the root LICENSE and package metadata
- update docs and policy references to the renamed repository (webrenew/agent-observer)
- refresh web installer/release URL sources to pull from the renamed repository

## Validation
- pnpm run lint:desktop
- pnpm run lint:web
- pnpm run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily documentation/metadata URL updates plus a license text change; minimal runtime impact aside from the web release-fetch endpoint pointing to the new repo.
> 
> **Overview**
> Updates project licensing from **ISC to MIT** by replacing the root `LICENSE` text and aligning `README.md`, root `package.json`, and `web/package.json` metadata.
> 
> Refreshes repository references from `webrenew/agent-space` to `webrenew/agent-observer` across docs (`CHANGELOG.md`, `SECURITY.md`, `web/public/llms.txt`) and updates the web download code (`web/src/lib/site.ts`, `web/src/lib/downloads.ts`) to fetch latest release assets from the renamed GitHub repo/API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa85141f80179a02b5fab653fdae8ca5d712d02b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->