### PR TITLE
fix: reject long-running IPC starts during app shutdown

### DIFF
--- a/src/main/claude-session.ts
+++ b/src/main/claude-session.ts
@@ -7,6 +7,7 @@ import os from 'os'
 import { resolveClaudeProfileForDirectory } from './claude-profile'
 import { logMainError, logMainEvent } from './diagnostics'
 import { terminateManagedProcess } from './process-runner'
+import { assertAppNotShuttingDown } from './shutdown-state'
 
 // ── Types (mirrored from renderer, kept lightweight for main process) ──
 
@@ -816,6 +817,7 @@ export function setupClaudeSessionHandlers(_mainWindow: BrowserWindow): void {
   handlersRegistered = true
 
   ipcMain.handle('claude:start', (event, options: unknown) => {
+    assertAppNotShuttingDown('claude:start')
     // Validate input shape
     if (!options || typeof options !== 'object') {
       throw new Error('claude:start requires an options object')

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -25,6 +25,7 @@ import {
   logMainEvent,
   setupDiagnosticsHandlers,
 } from './diagnostics'
+import { markAppShuttingDown } from './shutdown-state'
 
 // Strip Claude session env vars so embedded terminals can launch Claude Code
 for (const key of Object.keys(process.env)) {
@@ -580,6 +581,7 @@ if (!gotTheLock) {
     let forceExitTimer: NodeJS.Timeout | null = null
 
     shutdownInProgress = true
+    markAppShuttingDown()
     recordTelemetryEvent('app.shutdown.config', {
       stepTimeoutMs: shutdownConfig.stepTimeoutMs,
       totalTimeoutMs: shutdownConfig.totalTimeoutMs,

--- a/src/main/scheduler.ts
+++ b/src/main/scheduler.ts
@@ -14,6 +14,7 @@ import {
   scheduleManagedForceKill,
   terminateManagedProcess,
 } from './process-runner'
+import { assertAppNotShuttingDown } from './shutdown-state'
 
 type SchedulerRunStatus = 'idle' | 'running' | 'success' | 'error'
 type SchedulerRunTrigger = 'cron' | 'manual'
@@ -1109,14 +1110,17 @@ export function setupSchedulerHandlers(): void {
   })
 
   ipcMain.handle('scheduler:upsert', async (_event, input: SchedulerTaskInput) => {
+    assertAppNotShuttingDown('scheduler:upsert')
     return upsertTask(input)
   })
 
   ipcMain.handle('scheduler:delete', async (_event, taskId: string) => {
+    assertAppNotShuttingDown('scheduler:delete')
     deleteTask(taskId)
   })
 
   ipcMain.handle('scheduler:runNow', async (_event, taskId: string) => {
+    assertAppNotShuttingDown('scheduler:runNow')
     return await runTaskById(taskId, 'manual')
   })
 

--- a/src/main/shutdown-state.ts
+++ b/src/main/shutdown-state.ts
@@ -1,0 +1,29 @@
+const APP_SHUTTING_DOWN_ERROR_CODE = 'APP_SHUTTING_DOWN'
+
+let appShuttingDown = false
+
+export class AppShuttingDownError extends Error {
+  readonly code = APP_SHUTTING_DOWN_ERROR_CODE
+
+  constructor(operation: string) {
+    super(`[${APP_SHUTTING_DOWN_ERROR_CODE}] ${operation} is unavailable while app is shutting down`)
+    this.name = 'AppShuttingDownError'
+  }
+}
+
+export function markAppShuttingDown(): void {
+  appShuttingDown = true
+}
+
+export function isAppShuttingDown(): boolean {
+  return appShuttingDown
+}
+
+export function assertAppNotShuttingDown(operation: string): void {
+  if (!isAppShuttingDown()) return
+  throw new AppShuttingDownError(operation)
+}
+
+export function __testOnlyResetAppShutdownState(): void {
+  appShuttingDown = false
+}

--- a/src/main/todo-runner.ts
+++ b/src/main/todo-runner.ts
@@ -12,6 +12,7 @@ import {
   scheduleManagedForceKill,
   terminateManagedProcess,
 } from './process-runner'
+import { assertAppNotShuttingDown } from './shutdown-state'
 
 type TodoRunnerRunStatus = 'idle' | 'running' | 'success' | 'error'
 type TodoRunnerRunTrigger = 'auto' | 'manual'
@@ -1084,22 +1085,27 @@ export function setupTodoRunnerHandlers(): void {
   })
 
   ipcMain.handle('todoRunner:upsert', async (_event, input: TodoRunnerJobInput) => {
+    assertAppNotShuttingDown('todoRunner:upsert')
     return upsertJob(input)
   })
 
   ipcMain.handle('todoRunner:delete', async (_event, jobId: string) => {
+    assertAppNotShuttingDown('todoRunner:delete')
     deleteJob(jobId)
   })
 
   ipcMain.handle('todoRunner:start', async (_event, jobId: string) => {
+    assertAppNotShuttingDown('todoRunner:start')
     return startJob(jobId)
   })
 
   ipcMain.handle('todoRunner:pause', async (_event, jobId: string) => {
+    assertAppNotShuttingDown('todoRunner:pause')
     return pauseJob(jobId)
   })
 
   ipcMain.handle('todoRunner:reset', async (_event, jobId: string) => {
+    assertAppNotShuttingDown('todoRunner:reset')
     return resetJob(jobId)
   })
 }

--- a/tests/smoke/shutdown-state.spec.ts
+++ b/tests/smoke/shutdown-state.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test'
+import {
+  __testOnlyResetAppShutdownState,
+  assertAppNotShuttingDown,
+  markAppShuttingDown,
+} from '../../src/main/shutdown-state'
+
+test.afterEach(() => {
+  __testOnlyResetAppShutdownState()
+})
+
+test('shutdown guard allows operations before shutdown starts', () => {
+  expect(() => assertAppNotShuttingDown('scheduler:runNow')).not.toThrow()
+})
+
+test('shutdown guard throws deterministic APP_SHUTTING_DOWN error', () => {
+  markAppShuttingDown()
+  let thrown: unknown = null
+  try {
+    assertAppNotShuttingDown('claude:start')
+  } catch (err) {
+    thrown = err
+  }
+
+  expect(thrown).toBeInstanceOf(Error)
+  expect(String((thrown as Error).message)).toContain('APP_SHUTTING_DOWN')
+})


### PR DESCRIPTION
## Summary
- add shared main-process shutdown state with deterministic APP_SHUTTING_DOWN errors
- mark shutdown state at the start of before-quit coordinated shutdown
- enforce shutdown guard in mutating/starting IPC handlers for claude sessions, scheduler, and todo runner
- add smoke tests for shutdown guard behavior

## Validation
- pnpm run lint:desktop
- pnpm run typecheck
- pnpm exec playwright test -c playwright.smoke.config.ts --workers=1

Closes #135

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change that only adds early-rejection guards to IPC entrypoints during shutdown; main risk is unexpected client-facing errors if callers invoke these IPCs late in shutdown.
> 
> **Overview**
> Prevents new long-running work from starting once Electron shutdown begins by introducing a shared main-process shutdown flag and throwing a deterministic `AppShuttingDownError` (`APP_SHUTTING_DOWN`).
> 
> `markAppShuttingDown()` is triggered at the start of `before-quit`, and shutdown guards are added to IPC handlers that create/mutate work (`claude:start`, scheduler upsert/delete/run, and todo-runner upsert/delete/start/pause/reset). A new smoke test asserts the guard allows operations before shutdown and rejects them after shutdown starts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb92677e0837886c8d7cdb50c7a11ac60bbfa8bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->