### PR TITLE
fix: drain scheduler dispatch promises during cleanup

### DIFF
--- a/tests/smoke/scheduler-shutdown-dispatch.spec.ts
+++ b/tests/smoke/scheduler-shutdown-dispatch.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test'
+import {
+  __testOnlyCanDispatchPendingCronRun,
+  __testOnlyShouldRequeuePendingCronRun,
+} from '../../src/main/scheduler'
+
+test('scheduler dispatch gating blocks dispatch while shutting down', () => {
+  expect(__testOnlyCanDispatchPendingCronRun(false, false, false)).toBe(true)
+  expect(__testOnlyCanDispatchPendingCronRun(true, false, false)).toBe(false)
+  expect(__testOnlyCanDispatchPendingCronRun(false, true, false)).toBe(false)
+  expect(__testOnlyCanDispatchPendingCronRun(false, false, true)).toBe(false)
+})
+
+test('scheduler pending run requeue skips during shutdown', () => {
+  expect(__testOnlyShouldRequeuePendingCronRun(false, false)).toBe(true)
+  expect(__testOnlyShouldRequeuePendingCronRun(false, true)).toBe(false)
+  expect(__testOnlyShouldRequeuePendingCronRun(true, false)).toBe(false)
+  expect(__testOnlyShouldRequeuePendingCronRun(true, true)).toBe(false)
+})


### PR DESCRIPTION
## Summary
- track in-flight scheduler dispatch promises per task and block new dispatches during shutdown
- drain tracked dispatch promises with a bounded timeout inside cleanupScheduler()
- add smoke coverage for shutdown dispatch gating and requeue behavior while shutting down

Closes #136

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shutdown/cleanup behavior and cron dispatch queueing; incorrect gating or timeouts could drop scheduled runs or leave work stuck during app exit, but changes are bounded and covered by smoke tests.
> 
> **Overview**
> Prevents new cron dispatches from starting while the scheduler is shutting down and avoids re-queuing pending runs during shutdown.
> 
> Tracks per-task in-flight dispatch promises and, during `cleanupScheduler()`, waits for them to settle with a configurable, bounded drain timeout (`AGENT_SPACE_SCHEDULER_DISPATCH_DRAIN_TIMEOUT_MS`), logging completion vs timeout before clearing scheduler state. Adds smoke tests for the shutdown dispatch gating and requeue rules via exported `__testOnly*` helpers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f217bad2c67a91bd65723a78cfd6f171ef36babd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->