### PR TITLE
fix: drain todo-runner dispatch promises during cleanup

### DIFF
--- a/tests/smoke/todo-runner-shutdown-dispatch.spec.ts
+++ b/tests/smoke/todo-runner-shutdown-dispatch.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '@playwright/test'
+import {
+  __testOnlyCanDispatchTodoRun,
+  __testOnlyWaitForTodoRunPromises,
+} from '../../src/main/todo-runner'
+
+test('todo-runner dispatch gating blocks starts while shutting down', () => {
+  expect(__testOnlyCanDispatchTodoRun(false, false, false, false)).toBe(true)
+  expect(__testOnlyCanDispatchTodoRun(true, false, false, false)).toBe(false)
+  expect(__testOnlyCanDispatchTodoRun(false, true, false, false)).toBe(false)
+  expect(__testOnlyCanDispatchTodoRun(false, false, true, false)).toBe(false)
+  expect(__testOnlyCanDispatchTodoRun(false, false, false, true)).toBe(false)
+})
+
+test('todo-runner dispatch drain reports completion when all runs settle', async () => {
+  let resolveRun: (() => void) | null = null
+  const runPromise = new Promise<void>((resolve) => {
+    resolveRun = resolve
+  })
+
+  const drainPromise = __testOnlyWaitForTodoRunPromises([runPromise], 200)
+  expect(resolveRun).not.toBeNull()
+  resolveRun?.()
+
+  await expect(drainPromise).resolves.toEqual({
+    drained: true,
+    pendingCount: 0,
+  })
+})
+
+test('todo-runner dispatch drain reports timeout when runs stay in-flight', async () => {
+  const neverSettles = new Promise<void>(() => {})
+  const result = await __testOnlyWaitForTodoRunPromises([neverSettles], 1)
+  expect(result).toEqual({
+    drained: false,
+    pendingCount: 1,
+  })
+})


### PR DESCRIPTION
## Summary
- add a todo-runner shutdown gate that blocks new dispatch reservations and run starts during cleanup
- track in-flight `runTodo()` promises per job and drain them with a bounded timeout in `cleanupTodoRunner()`
- add smoke tests for shutdown dispatch gating and bounded in-flight drain behavior

Closes #137

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches todo-runner scheduling and shutdown/cleanup paths; mistakes could cause missed runs or hang/slow shutdown, though behavior is bounded by a configurable timeout and covered by new smoke tests.
> 
> **Overview**
> Prevents the todo-runner from starting new work during shutdown by adding a `todoRunnerShuttingDown` gate and expanding dispatch eligibility to also block jobs with an in-flight `runTodo()` promise.
> 
> Tracks per-job `runTodo()` promises (`runPromiseByJobId`) and, during `cleanupTodoRunner()`, waits for these dispatch promises to settle with a configurable, bounded timeout (`AGENT_SPACE_TODO_RUNNER_DISPATCH_DRAIN_TIMEOUT_MS`) before terminating any running processes; adds smoke tests covering both the dispatch gating and drain timeout behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa0c4a031153306203ab1fa123446d3a3439d5bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->