### PR TITLE
fix: terminate managed process trees for shell runners

### DIFF
--- a/tests/smoke/process-shutdown.spec.ts
+++ b/tests/smoke/process-shutdown.spec.ts
@@ -1,7 +1,10 @@
 import { spawn, type ChildProcess } from 'child_process'
 import { once } from 'events'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
 import { expect, test } from '@playwright/test'
-import { terminateManagedProcess } from '../../src/main/process-runner'
+import { runManagedProcess, terminateManagedProcess } from '../../src/main/process-runner'
 
 async function forceKillIfRunning(childProcess: ChildProcess): Promise<void> {
   if (childProcess.exitCode !== null || childProcess.signalCode !== null) return
@@ -15,6 +18,34 @@ async function forceKillIfRunning(childProcess: ChildProcess): Promise<void> {
   } catch {
     // Ignore post-kill wait failures in test cleanup.
   }
+}
+
+function isPidRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function waitForPidExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + Math.max(1, timeoutMs)
+  while (Date.now() < deadline) {
+    if (!isPidRunning(pid)) return true
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+  return !isPidRunning(pid)
+}
+
+async function forceKillPidIfRunning(pid: number): Promise<void> {
+  if (!isPidRunning(pid)) return
+  try {
+    process.kill(pid, 'SIGKILL')
+  } catch {
+    // PID may have exited between checks.
+  }
+  await waitForPidExit(pid, 500)
 }
 
 test('termination helper is a no-op for already exited processes', async () => {
@@ -76,5 +107,52 @@ test('termination helper escalates to SIGKILL after SIGTERM deadline', async () 
     expect(result.signalCode).toBe('SIGKILL')
   } finally {
     await forceKillIfRunning(childProcess)
+  }
+})
+
+test('managed shell timeout terminates descendant process trees', async () => {
+  test.skip(process.platform === 'win32', 'POSIX process-group signaling only')
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-observer-process-tree-'))
+  const pidFile = path.join(tempDir, 'descendant.pid')
+  const descendantScript = 'process.on("SIGTERM", () => {}); setInterval(() => {}, 1000)'
+  const parentScript = [
+    'const fs = require("fs")',
+    'const { spawn } = require("child_process")',
+    `const child = spawn(process.execPath, ['-e', ${JSON.stringify(descendantScript)}], { stdio: "ignore" })`,
+    `fs.writeFileSync(${JSON.stringify(pidFile)}, String(child.pid))`,
+    'process.on("SIGTERM", () => {})',
+    'setInterval(() => {}, 1000)',
+  ].join('; ')
+  const shellCommand = `${JSON.stringify(process.execPath)} -e ${JSON.stringify(parentScript)}`
+
+  let descendantPid: number | null = null
+  try {
+    const result = await runManagedProcess({
+      command: shellCommand,
+      spawnOptions: {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        shell: true,
+      },
+      maxRuntimeMs: 500,
+      forceKillTimeoutMs: 200,
+      timeoutErrorMessage: 'managed timeout',
+    })
+
+    expect(result.timedOut).toBe(true)
+    const pidRaw = fs.existsSync(pidFile) ? fs.readFileSync(pidFile, 'utf8').trim() : ''
+    const parsedPid = Number.parseInt(pidRaw, 10)
+    if (Number.isFinite(parsedPid) && parsedPid > 0) {
+      descendantPid = parsedPid
+    }
+    expect(descendantPid).not.toBeNull()
+    const pid = descendantPid as number
+    expect(await waitForPidExit(pid, 2_000)).toBe(true)
+    expect(isPidRunning(pid)).toBe(false)
+  } finally {
+    if (descendantPid !== null) {
+      await forceKillPidIfRunning(descendantPid)
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true })
   }
 })


### PR DESCRIPTION
## Summary
- spawn managed commands in dedicated POSIX process groups by default and record group-aware kill eligibility per process
- route managed SIGTERM/SIGKILL signaling through process-group kill paths with single-process fallback for unsupported/error cases
- add a smoke test that validates a shell-launched descendant process is terminated by managed timeout/force-kill handling

Closes #138

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core process spawning/termination semantics (enabling `detached` and process-group kills), which can impact shutdown behavior across platforms and edge cases despite having fallback logic and targeted tests.
> 
> **Overview**
> Managed process execution now *optionally* spawns commands in a dedicated POSIX process group (non-Windows, unless `detached: false`) and tracks per-child eligibility so termination can target the whole group.
> 
> All SIGTERM/SIGKILL paths (`terminateManagedProcess`, timeout handling in `runManagedProcess`, and `scheduleManagedForceKill`) now route through a new group-aware `sendSignal` that uses negative-PID `process.kill` with safe fallback to direct child signaling.
> 
> Adds a smoke test asserting a `shell: true` managed timeout kills a spawned descendant process (skipped on Windows).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab8f436026e50723e38d0c08386b2c25cab9bb82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->