### PR TITLE
fix: await scheduler task stop outcome during delete

### DIFF
--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -405,7 +405,10 @@ export function SettingsPanel() {
     }
 
     await runSchedulerAction(task, async () => {
-      await window.electronAPI.scheduler.delete(task.id)
+      const result = await window.electronAPI.scheduler.delete(task.id)
+      if (!result.stopped) {
+        throw new Error('Delete timed out while stopping the running scheduler task')
+      }
     })
   }, [runSchedulerAction])
 

--- a/src/shared/electron-api.ts
+++ b/src/shared/electron-api.ts
@@ -166,6 +166,14 @@ export interface ChatMemoryWrite {
   workspacePath: string
 }
 
+export interface SchedulerDeleteResult {
+  taskId: string
+  wasRunning: boolean
+  stopped: boolean
+  forced: boolean
+  timedOut: boolean
+}
+
 export interface ElectronAPI {
   versions: {
     node: string
@@ -248,7 +256,7 @@ export interface ElectronAPI {
   scheduler: {
     list: () => Promise<SchedulerTask[]>
     upsert: (task: SchedulerTaskInput) => Promise<SchedulerTask>
-    delete: (taskId: string) => Promise<void>
+    delete: (taskId: string) => Promise<SchedulerDeleteResult>
     runNow: (taskId: string) => Promise<SchedulerTask>
     debugRuntimeSize: () => Promise<number>
     onUpdated: (callback: () => void) => Unsubscribe


### PR DESCRIPTION
## Summary
- make scheduler deletion await running-task termination with a structured stop result (`wasRunning`, `stopped`, `forced`, `timedOut`)
- surface delete-stop lifecycle logs and keep timed-out deletions in-place (paused) so timeout is visible before deletion completion
- update shared API types, settings delete UX handling, and smoke coverage for delete-while-running stop outcomes

Closes #139

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core scheduler deletion and process-termination flow and IPC contract; mistakes could leave tasks stuck/incorrectly retained or cause UI regressions when deletes occur during runs.
> 
> **Overview**
> Scheduler task deletion now *waits for any running process to terminate* and returns a structured `SchedulerDeleteResult` (`wasRunning`, `stopped`, `forced`, `timedOut`) instead of fire-and-forget SIGTERM.
> 
> If stopping times out, the task is **not removed**; it’s disabled, pending runs are cleared, runtime is marked error, and detailed delete/stop lifecycle logs are emitted. The renderer settings UI and smoke tests are updated to consume/validate the new delete result and surface a timeout as an error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d9c9012c52fa452b911113e3e472279f39b97f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->