### PR TITLE
fix: await todo-runner pause and delete stop outcomes

### DIFF
--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -486,7 +486,10 @@ export function SettingsPanel() {
     }
 
     await runTodoRunnerAction(job, async () => {
-      await window.electronAPI.todoRunner.delete(job.id)
+      const result = await window.electronAPI.todoRunner.delete(job.id)
+      if (!result.stopped || !result.deleted) {
+        throw new Error('Delete timed out while stopping the running todo runner job')
+      }
     })
   }, [runTodoRunnerAction])
 
@@ -519,7 +522,10 @@ export function SettingsPanel() {
     if (job.isDraft) return
 
     await runTodoRunnerAction(job, async () => {
-      await window.electronAPI.todoRunner.pause(job.id)
+      const result = await window.electronAPI.todoRunner.pause(job.id)
+      if (!result.stopOutcome.stopped) {
+        throw new Error('Pause timed out while stopping the running todo runner job')
+      }
     })
   }, [runTodoRunnerAction])
 

--- a/src/shared/electron-api.ts
+++ b/src/shared/electron-api.ts
@@ -174,6 +174,23 @@ export interface SchedulerDeleteResult {
   timedOut: boolean
 }
 
+export interface TodoRunnerStopOutcome {
+  jobId: string
+  wasRunning: boolean
+  stopped: boolean
+  forced: boolean
+  timedOut: boolean
+}
+
+export interface TodoRunnerDeleteResult extends TodoRunnerStopOutcome {
+  deleted: boolean
+}
+
+export interface TodoRunnerPauseResult {
+  job: TodoRunnerJob
+  stopOutcome: TodoRunnerStopOutcome
+}
+
 export interface ElectronAPI {
   versions: {
     node: string
@@ -264,9 +281,9 @@ export interface ElectronAPI {
   todoRunner: {
     list: () => Promise<TodoRunnerJob[]>
     upsert: (job: TodoRunnerJobInput) => Promise<TodoRunnerJob>
-    delete: (jobId: string) => Promise<void>
+    delete: (jobId: string) => Promise<TodoRunnerDeleteResult>
     start: (jobId: string) => Promise<TodoRunnerJob>
-    pause: (jobId: string) => Promise<TodoRunnerJob>
+    pause: (jobId: string) => Promise<TodoRunnerPauseResult>
     reset: (jobId: string) => Promise<TodoRunnerJob>
     onUpdated: (callback: () => void) => Unsubscribe
   }


### PR DESCRIPTION
## Summary
- replace fire-and-forget todo-runner pause/delete stop logic with awaited termination outcomes from managed process termination
- return explicit stop outcome metadata (including timeout/force-kill) from todo-runner pause/delete IPC handlers and shared API types
- update settings actions and desktop smoke assertions to reflect real stop lifecycle before reporting paused/deleted state

Closes #140

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process termination and IPC contract for pausing/deleting jobs; incorrect handling could leave jobs running, fail to delete, or surface new UI errors under timeout/kill edge cases.
> 
> **Overview**
> Fixes `todoRunner` pause/delete to *await* managed process termination instead of fire-and-forget SIGTERM + delayed force-kill.
> 
> Main-process handlers now return structured results (`TodoRunnerStopOutcome`, `TodoRunnerDeleteResult`, `TodoRunnerPauseResult`) including whether the job was running, whether it stopped, and whether termination timed out or escalated to SIGKILL; delete additionally disables the job (without deleting) on stop timeout and cleans up more per-job state on success.
> 
> Renderer settings actions and smoke tests are updated to consume these return values and surface timeout failures (throwing when pause/delete didn’t fully stop/delete).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aec3f34f52f26f6f6ead5b4c9f432fc9ea777ebb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->