### PR TITLE
fix: bound scheduler pending cron backlog per task

### DIFF
--- a/tests/smoke/scheduler-backlog-limit.spec.ts
+++ b/tests/smoke/scheduler-backlog-limit.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test'
+import { __testOnlyBoundPendingCronQueueByLimit } from '../../src/main/scheduler'
+
+test('scheduler backlog cap drops oldest queue entries first', () => {
+  const queue = ['m1', 'm2', 'm3', 'm4', 'm5']
+  const bounded = __testOnlyBoundPendingCronQueueByLimit(queue, 2)
+
+  expect(bounded.keptQueue).toEqual(['m4', 'm5'])
+  expect(bounded.droppedQueue).toEqual(['m1', 'm2', 'm3'])
+})
+
+test('scheduler backlog cap keeps queue intact when under limit', () => {
+  const queue = ['m1', 'm2']
+  const bounded = __testOnlyBoundPendingCronQueueByLimit(queue, 4)
+
+  expect(bounded.keptQueue).toEqual(['m1', 'm2'])
+  expect(bounded.droppedQueue).toEqual([])
+})
+
+test('scheduler backlog cap normalizes invalid limits to one entry', () => {
+  const queue = ['m1', 'm2', 'm3']
+  const bounded = __testOnlyBoundPendingCronQueueByLimit(queue, 0)
+
+  expect(bounded.keptQueue).toEqual(['m3'])
+  expect(bounded.droppedQueue).toEqual(['m1', 'm2'])
+})

--- a/web/content/docs/guides/scheduled-actions.mdx
+++ b/web/content/docs/guides/scheduled-actions.mdx
@@ -89,6 +89,14 @@ After saving a schedule:
 - Manual and cron-triggered runs share the same execution path.
 - Schedule definitions are persisted locally.
 
+### Pending Backlog Cap
+
+- Pending cron backlog is bounded per task to prevent unbounded memory growth.
+- Default per-task cap: `240` pending minute entries.
+- Oldest pending entries are dropped first (newest entries are retained).
+- Operator signal: diagnostics event `scheduler.tick.backlog_capped`.
+- Optional override: `AGENT_SPACE_SCHEDULER_PENDING_BACKLOG_LIMIT` (`1` to `1440`).
+
 Persistence location:
 
 - `~/.agent-observer/schedules.json`

--- a/web/content/docs/reference/troubleshooting.mdx
+++ b/web/content/docs/reference/troubleshooting.mdx
@@ -48,6 +48,7 @@ Fix:
 3. Confirm app was open at trigger time.
 4. Use **Run now** to test immediate execution path.
 5. Verify working directory exists.
+6. If runs stay behind, check diagnostics for `scheduler.tick.backlog_capped` (oldest pending entries are dropped when per-task backlog reaches `AGENT_SPACE_SCHEDULER_PENDING_BACKLOG_LIMIT`, default `240`).
 
 ## Scheduled Action Fails Immediately
 


### PR DESCRIPTION
## Summary\n- add a per-task scheduler pending backlog cap with deterministic oldest-first dropping\n- make the cap configurable via AGENT_SPACE_SCHEDULER_PENDING_BACKLOG_LIMIT with validation/clamping logs\n- cap requeue paths and surface backlog stats in scheduler tick diagnostics\n- add deterministic smoke tests for the backlog limiter helper\n- document backlog policy and troubleshooting guidance\n\n## Testing\n- pnpm run lint:desktop\n- pnpm run typecheck\n- pnpm run build\n- pnpm exec playwright test -c playwright.smoke.config.ts --workers=1\n\nCloses #141

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes scheduler queueing/requeueing behavior and can drop scheduled runs under sustained backlog; issues could cause missed or delayed executions, though the change is localized and guarded by logging/tests.
> 
> **Overview**
> Bounds *per-task* pending cron queues to prevent unbounded memory growth by capping backlog size and deterministically dropping the **oldest** pending minutes first (newest retained), applied on both enqueue and requeue paths.
> 
> Adds `AGENT_SPACE_SCHEDULER_PENDING_BACKLOG_LIMIT` with validation/clamping logs, emits a new `scheduler.tick.backlog_capped` warn event when trimming occurs, and extends tick diagnostics to report pending counts and the active limit. Includes smoke tests for the queue-bounding helper and updates scheduled-actions + troubleshooting docs to describe the new backlog policy and operator signals.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eaf5e6c6c8974a38eddf7b5c631234a1c09903e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->