### PR TITLE
fix: add todo-runner retry cooldown backoff

### DIFF
--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -473,6 +473,7 @@ export function SettingsPanel() {
       blockedTodos: 0,
       currentTodoIndex: null,
       nextTodoText: null,
+      nextRetryAt: null,
       isDraft: true,
       todoItemsText: '',
     }

--- a/src/renderer/components/settings/TodoRunnerTab.tsx
+++ b/src/renderer/components/settings/TodoRunnerTab.tsx
@@ -241,6 +241,9 @@ export function TodoRunnerTab({
                 Current todo: {job.currentTodoIndex != null ? String(job.currentTodoIndex + 1) : 'None'}
               </div>
               <div>Next todo: {job.nextTodoText ?? 'None'}</div>
+              {job.nextRetryAt != null && (
+                <div>Next retry: {formatDateTime(job.nextRetryAt)}</div>
+              )}
               <div>
                 Last run: {formatDateTime(job.lastRunAt)}
                 {job.lastDurationMs != null ? ` (${formatDuration(job.lastDurationMs)})` : ''}

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -283,6 +283,7 @@ export interface TodoRunnerJob {
   blockedTodos: number
   currentTodoIndex: number | null
   nextTodoText: string | null
+  nextRetryAt: number | null
 }
 
 export interface Scope {

--- a/tests/smoke/todo-runner-concurrency.spec.ts
+++ b/tests/smoke/todo-runner-concurrency.spec.ts
@@ -1,9 +1,11 @@
 import { expect, test } from '@playwright/test'
 import {
   __testOnlyCollectStaleRunningTodoIndices,
+  __testOnlyComputeTodoRetryBackoffMs,
   __testOnlyComputeTodoRunnerAvailableSlots,
   __testOnlyFindNextRunnableTodoIndex,
   __testOnlyIsTodoJobDispatchEligible,
+  __testOnlyIsTodoRetryReady,
 } from '../../src/main/todo-runner'
 
 test('slow-spawn reservation consumes slot before process bookkeeping updates', () => {
@@ -56,4 +58,29 @@ test('stale running reconciliation targets only running statuses', () => {
     { status: 'running' as const },
   ])
   expect(staleIndexes).toEqual([0, 3])
+})
+
+test('retry backoff is deterministic and capped', () => {
+  expect(__testOnlyComputeTodoRetryBackoffMs(1)).toBe(15_000)
+  expect(__testOnlyComputeTodoRetryBackoffMs(2)).toBe(30_000)
+  expect(__testOnlyComputeTodoRetryBackoffMs(3)).toBe(60_000)
+  expect(__testOnlyComputeTodoRetryBackoffMs(99)).toBe(5 * 60 * 1000)
+})
+
+test('retry readiness helper respects next retry timestamp', () => {
+  const now = 1_700_000_000_000
+  expect(__testOnlyIsTodoRetryReady(null, now)).toBe(true)
+  expect(__testOnlyIsTodoRetryReady(now - 1, now)).toBe(true)
+  expect(__testOnlyIsTodoRetryReady(now + 1, now)).toBe(false)
+})
+
+test('candidate selection holds job on first cooling-down todo', () => {
+  const now = 1_700_000_000_000
+  const todos = [
+    { status: 'error' as const, attempts: 1, nextRetryAt: now + 30_000 },
+    { status: 'pending' as const, attempts: 0, nextRetryAt: null },
+  ]
+
+  expect(__testOnlyFindNextRunnableTodoIndex(todos, now)).toBeNull()
+  expect(__testOnlyFindNextRunnableTodoIndex(todos, now + 30_000)).toBe(0)
 })

--- a/web/content/docs/guides/todo-runner.mdx
+++ b/web/content/docs/guides/todo-runner.mdx
@@ -50,6 +50,8 @@ Each job includes:
 - One item is active at a time.
 - Success marks item as done and advances.
 - Failure retries up to 3 attempts per item.
+- Failed retries use deterministic exponential cooldown (`15s`, `30s`, `60s`, capped at `5m`).
+- Job card surfaces the next retry timestamp when an item is cooling down.
 - Item hitting max attempts becomes blocked; job pauses.
 - You can **Pause**, **Start**, or **Reset Progress**.
 

--- a/web/content/docs/reference/ipc-api.mdx
+++ b/web/content/docs/reference/ipc-api.mdx
@@ -57,9 +57,9 @@ Methods:
 
 - `list(): Promise<TodoRunnerJob[]>`
 - `upsert(job: TodoRunnerJobInput): Promise<TodoRunnerJob>`
-- `delete(jobId: string): Promise<void>`
+- `delete(jobId: string): Promise<TodoRunnerDeleteResult>`
 - `start(jobId: string): Promise<TodoRunnerJob>`
-- `pause(jobId: string): Promise<TodoRunnerJob>`
+- `pause(jobId: string): Promise<TodoRunnerPauseResult>`
 - `reset(jobId: string): Promise<TodoRunnerJob>`
 - `onUpdated(callback: () => void): Unsubscribe`
 
@@ -94,6 +94,7 @@ Returned jobs include runtime/progress fields:
 - `blockedTodos`
 - `currentTodoIndex`
 - `nextTodoText`
+- `nextRetryAt`
 
 Persistence location:
 

--- a/web/content/docs/reference/troubleshooting.mdx
+++ b/web/content/docs/reference/troubleshooting.mdx
@@ -70,7 +70,8 @@ Fix:
 1. Capture stderr/error from runner output.
 2. Reproduce the item manually outside Todo Runner.
 3. Fix dependency or prompt issue.
-4. Click **Start** to continue from remaining items.
+4. Check the job card's **Next retry** timestamp to confirm backoff cadence.
+5. Click **Start** to continue from remaining items.
 
 If attempts reached max and item is blocked:
 


### PR DESCRIPTION
## Summary
- add deterministic exponential retry cooldown metadata (`nextRetryAt`) per todo item
- block runnable selection while the next todo is still in cooldown to prevent retry storms
- emit retry scheduling diagnostics with backoff and next retry timestamp
- surface next retry timestamp in todo runner runtime view
- document backoff behavior and refresh IPC/runtime docs

## Testing
- pnpm run lint:desktop
- pnpm run typecheck
- pnpm run build
- pnpm exec playwright test -c playwright.smoke.config.ts --workers=1

Closes #142