### PR TITLE
fix: persist scheduler minute dedupe ledger

### DIFF
--- a/tests/smoke/scheduler-minute-ledger.spec.ts
+++ b/tests/smoke/scheduler-minute-ledger.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from '@playwright/test'
+import {
+  __testOnlyPruneSchedulerMinuteLedgerEntries,
+  __testOnlyShouldEnqueuePendingCronMinute,
+} from '../../src/main/scheduler'
+
+test('scheduler minute ledger pruning keeps newest active entries in retention window', () => {
+  const now = 1_700_000_000_000
+  const oneMinute = 60_000
+
+  const pruned = __testOnlyPruneSchedulerMinuteLedgerEntries(
+    [
+      { taskId: 'task-a', minuteKey: '2026-2-16-10-00', recordedAtMs: now - (120 * oneMinute) },
+      { taskId: 'task-a', minuteKey: '2026-2-16-11-59', recordedAtMs: now - (1 * oneMinute) },
+      { taskId: 'task-b', minuteKey: '2026-2-16-11-45', recordedAtMs: now - (15 * oneMinute) },
+      { taskId: 'task-c', minuteKey: '2026-2-16-11-50', recordedAtMs: now - (10 * oneMinute) },
+    ],
+    now,
+    60,
+    ['task-a', 'task-b']
+  )
+
+  expect(pruned.keptEntries).toEqual([
+    { taskId: 'task-a', minuteKey: '2026-2-16-11-59', recordedAtMs: now - (1 * oneMinute) },
+    { taskId: 'task-b', minuteKey: '2026-2-16-11-45', recordedAtMs: now - (15 * oneMinute) },
+  ])
+  expect(pruned.droppedEntries).toEqual([
+    { taskId: 'task-c', minuteKey: '2026-2-16-11-50', recordedAtMs: now - (10 * oneMinute) },
+    { taskId: 'task-a', minuteKey: '2026-2-16-10-00', recordedAtMs: now - (120 * oneMinute) },
+  ])
+})
+
+test('scheduler minute enqueue dedupe only skips exact already-processed minute', () => {
+  const lastRunMinuteKey = '2026-2-16-10-05'
+  const pendingMinuteKeys = ['2026-2-16-10-06']
+
+  expect(__testOnlyShouldEnqueuePendingCronMinute(lastRunMinuteKey, pendingMinuteKeys, '2026-2-16-10-05')).toBe(false)
+  expect(__testOnlyShouldEnqueuePendingCronMinute(lastRunMinuteKey, pendingMinuteKeys, '2026-2-16-10-06')).toBe(false)
+  expect(__testOnlyShouldEnqueuePendingCronMinute(lastRunMinuteKey, pendingMinuteKeys, '2026-2-16-10-04')).toBe(true)
+  expect(__testOnlyShouldEnqueuePendingCronMinute(lastRunMinuteKey, pendingMinuteKeys, '2026-2-16-10-07')).toBe(true)
+})

--- a/web/content/docs/guides/scheduled-actions.mdx
+++ b/web/content/docs/guides/scheduled-actions.mdx
@@ -97,9 +97,17 @@ After saving a schedule:
 - Operator signal: diagnostics event `scheduler.tick.backlog_capped`.
 - Optional override: `AGENT_SPACE_SCHEDULER_PENDING_BACKLOG_LIMIT` (`1` to `1440`).
 
+### Minute Dedupe Ledger
+
+- Scheduler persists the last processed cron minute per task across app restarts.
+- Deduplication window defaults to `1440` minutes (`24h`).
+- Optional override: `AGENT_SPACE_SCHEDULER_MINUTE_LEDGER_RETENTION_MINUTES` (`0` to `43200`).
+- Operator signal: diagnostics event `scheduler.ledger.pruned`.
+
 Persistence location:
 
 - `~/.agent-observer/schedules.json`
+- `~/.agent-observer/scheduler-minute-ledger.json`
 
 ## Failure Modes And Fixes
 

--- a/web/content/docs/reference/troubleshooting.mdx
+++ b/web/content/docs/reference/troubleshooting.mdx
@@ -57,6 +57,12 @@ Fix:
 3. Verify runtime dependencies for your command/tooling.
 4. Tighten prompt and retry manually.
 
+## Duplicate Scheduled Run After Restart
+
+1. Check diagnostics for `scheduler.ledger.pruned`.
+2. Verify `AGENT_SPACE_SCHEDULER_MINUTE_LEDGER_RETENTION_MINUTES` is not set too low.
+3. Confirm `~/.agent-observer/scheduler-minute-ledger.json` is writable.
+
 ## Todo Runner Job Not Progressing
 
 1. Verify **Runner command** exists and is executable.


### PR DESCRIPTION
## Summary
- persist per-task scheduler minute dedupe state to `~/.agent-observer/scheduler-minute-ledger.json`
- restore last processed minute key on startup so restarts do not re-run the same cron minute
- add retention-based ledger expiry with configurable window and pruning diagnostics
- preserve dedupe behavior for backfill windows by skipping only exact processed minute keys
- add smoke tests for ledger pruning/expiry and minute enqueue dedupe behavior
- document minute ledger behavior and troubleshooting guidance

## Testing
- pnpm run lint:desktop
- pnpm run typecheck
- pnpm run build
- pnpm exec playwright test -c playwright.smoke.config.ts --workers=1

Closes #143

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches scheduler run/dedupe logic and adds on-disk state with retention/pruning; incorrect ledger handling could cause missed or duplicate scheduled runs, but changes are localized and covered by smoke tests.
> 
> **Overview**
> Prevents duplicate cron executions after app restarts by adding a persisted per-task *minute dedupe ledger* (`~/.agent-observer/scheduler-minute-ledger.json`) and restoring `lastRunMinuteKey` from it on startup.
> 
> Adds retention-based pruning (configurable via `AGENT_SPACE_SCHEDULER_MINUTE_LEDGER_RETENTION_MINUTES`) with diagnostics (`scheduler.ledger.pruned`), persists ledger updates when runs start and when tasks are deleted, and refines enqueue dedupe to skip only the exact already-processed minute (not broader backfill windows). Includes smoke tests for pruning/dedupe behavior and documentation/troubleshooting updates for the new ledger.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a97bbae0e1868832a512666d2b9c99302b40008d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->