### PR TITLE
feat: explorer multi-type previews with staged diff review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - Open-source project governance docs and templates (`README`, `CONTRIBUTING`,
   `CODE_OF_CONDUCT`, `SECURITY`, issue templates, PR template, `CODEOWNERS`).
+- Explorer-driven file previews now support text/markdown/image/audio/video/PDF
+  modes with a binary metadata fallback and staged diff-preview saves for
+  text-like edits.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Agent Observer is a desktop-first observability workspace for AI agents, with a 
 
 - Monitor multiple AI agents in a shared 3D office and dashboard UI.
 - Track statuses, token flow, file modifications, and celebration/event streams.
+- Preview explorer-opened files across text, markdown, images, audio/video, and PDF
+  with staged diff review before text writes.
 - Run a production desktop app (Electron) plus a docs/demo web app (Next.js).
 - Integrate local workflows, scheduled actions, and memory tooling.
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -94,6 +94,7 @@ const electronAPI: ElectronAPI = {
     readDir: invokeFor<ElectronAPI['fs']['readDir']>(IPC_CHANNELS.fs.readDir),
     readFile: invokeFor<ElectronAPI['fs']['readFile']>(IPC_CHANNELS.fs.readFile),
     readImageDataUrl: invokeFor<ElectronAPI['fs']['readImageDataUrl']>(IPC_CHANNELS.fs.readImageDataUrl),
+    readDataUrl: invokeFor<ElectronAPI['fs']['readDataUrl']>(IPC_CHANNELS.fs.readDataUrl),
     search: invokeFor<ElectronAPI['fs']['search']>(IPC_CHANNELS.fs.search),
     homeDir: invokeFor<ElectronAPI['fs']['homeDir']>(IPC_CHANNELS.fs.homeDir),
     stat: invokeFor<ElectronAPI['fs']['stat']>(IPC_CHANNELS.fs.stat),

--- a/src/renderer/components/workspace/panels/FileEditorPanel.tsx
+++ b/src/renderer/components/workspace/panels/FileEditorPanel.tsx
@@ -1,14 +1,16 @@
 /**
- * FileEditorPanel — Monaco-based code editor with auto-LSP.
+ * FileEditorPanel — Monaco-based editor + multi-type preview panel.
  *
- * Listens for `file:open` custom events (dispatched by Explorer/Search panels).
- * Automatically starts the correct LSP server based on file extension,
- * and wires diagnostics back into Monaco markers.
+ * Listens for:
+ * - `file:open` custom events (Explorer/Search panels)
+ * - `file:propose-update` custom events (agent/user proposal flow)
+ *
+ * Text-like files support staged writes with diff preview.
  */
 
 import '../../../monaco-setup'
-import { useState, useEffect, useRef, useCallback } from 'react'
-import Editor, { type OnMount, type Monaco } from '@monaco-editor/react'
+import { useState, useEffect, useRef, useCallback, type CSSProperties, type ReactElement } from 'react'
+import Editor, { DiffEditor, type OnMount, type Monaco } from '@monaco-editor/react'
 import type { editor } from 'monaco-editor'
 import { useLspBridge } from '../../../hooks/useLspBridge'
 import { useSettingsStore } from '../../../store/settings'
@@ -53,35 +55,226 @@ function langColor(lang: string): string {
   }
 }
 
-// ── Binary detection ─────────────────────────────────────────────────
+// ── Preview-kind detection ────────────────────────────────────────────
+
+type PreviewKind = 'text' | 'markdown' | 'image' | 'audio' | 'video' | 'pdf' | 'binary'
+type ViewMode = 'edit' | 'preview' | 'diff'
+type ProposalSource = 'agent' | 'user'
+
+interface FileUpdateProposal {
+  path: string
+  content: string
+  source?: ProposalSource
+}
 
 const IMAGE_EXTS = new Set([
   'png', 'jpg', 'jpeg', 'gif', 'webp', 'ico', 'bmp', 'svg', 'avif',
 ])
 
-function isImageFile(name: string): boolean {
-  const ext = name.split('.').pop()?.toLowerCase() ?? ''
-  return IMAGE_EXTS.has(ext)
-}
+const MARKDOWN_EXTS = new Set(['md', 'mdx'])
+const AUDIO_EXTS = new Set(['mp3', 'wav', 'ogg', 'm4a', 'aac', 'flac'])
+const VIDEO_EXTS = new Set(['mp4', 'webm', 'mov', 'm4v', 'avi'])
+const PDF_EXTS = new Set(['pdf'])
 
 const BINARY_EXTS = new Set([
-  'png', 'jpg', 'jpeg', 'gif', 'webp', 'ico', 'bmp',
-  'mp3', 'mp4', 'wav', 'avi', 'mov', 'webm',
   'zip', 'gz', 'tar', 'rar', '7z',
   'woff', 'woff2', 'ttf', 'otf', 'eot',
-  'pdf', 'doc', 'docx', 'xls', 'xlsx',
+  'doc', 'docx', 'xls', 'xlsx',
   'exe', 'dll', 'so', 'dylib', 'node',
 ])
 
-function isBinary(name: string): boolean {
-  const ext = name.split('.').pop()?.toLowerCase() ?? ''
-  return BINARY_EXTS.has(ext)
+function extension(name: string): string {
+  return name.split('.').pop()?.toLowerCase() ?? ''
+}
+
+function detectPreviewKind(name: string): PreviewKind {
+  const ext = extension(name)
+  if (IMAGE_EXTS.has(ext)) return 'image'
+  if (MARKDOWN_EXTS.has(ext)) return 'markdown'
+  if (AUDIO_EXTS.has(ext)) return 'audio'
+  if (VIDEO_EXTS.has(ext)) return 'video'
+  if (PDF_EXTS.has(ext)) return 'pdf'
+  if (BINARY_EXTS.has(ext)) return 'binary'
+  return 'text'
+}
+
+function isTextPreviewKind(kind: PreviewKind): boolean {
+  return kind === 'text' || kind === 'markdown'
+}
+
+function defaultViewMode(kind: PreviewKind): ViewMode {
+  if (kind === 'markdown') return 'preview'
+  if (kind === 'text') return 'edit'
+  return 'preview'
+}
+
+function previewColor(kind: PreviewKind, lang: string): string {
+  if (kind === 'text' || kind === 'markdown') return langColor(lang)
+  if (kind === 'pdf') return '#c45050'
+  if (kind === 'binary') return '#74747C'
+  return '#6b8fa3'
+}
+
+function previewLabel(kind: PreviewKind, lang: string): string {
+  if (kind === 'text') return lang
+  return kind
 }
 
 function formatSize(bytes: number): string {
   if (bytes >= 1_000_000) return `${(bytes / 1_000_000).toFixed(1)} MB`
   if (bytes >= 1_000) return `${(bytes / 1_000).toFixed(1)} KB`
   return `${bytes} B`
+}
+
+function renderMarkdown(content: string): ReactElement[] {
+  const lines = content.replace(/\r\n/g, '\n').split('\n')
+  const elements: ReactElement[] = []
+  let key = 0
+
+  let paragraph: string[] = []
+  let listItems: string[] = []
+  let codeLines: string[] = []
+  let codeLang = ''
+  let inCode = false
+
+  const flushParagraph = () => {
+    if (paragraph.length === 0) return
+    elements.push(
+      <p key={`p-${key++}`} style={{ margin: '0 0 10px 0', lineHeight: 1.55 }}>
+        {paragraph.join(' ')}
+      </p>
+    )
+    paragraph = []
+  }
+
+  const flushList = () => {
+    if (listItems.length === 0) return
+    elements.push(
+      <ul key={`ul-${key++}`} style={{ margin: '0 0 10px 0', paddingLeft: 20 }}>
+        {listItems.map((item, itemIndex) => <li key={`li-${itemIndex}`}>{item}</li>)}
+      </ul>
+    )
+    listItems = []
+  }
+
+  const flushCode = () => {
+    elements.push(
+      <div key={`code-${key++}`} style={{ margin: '0 0 10px 0' }}>
+        {codeLang && (
+          <div style={{ fontSize: 10, color: '#595653', marginBottom: 4 }}>{codeLang}</div>
+        )}
+        <pre
+          style={{
+            margin: 0,
+            padding: 10,
+            background: '#141413',
+            border: '1px solid rgba(89,86,83,0.24)',
+            borderRadius: 6,
+            overflowX: 'auto',
+            whiteSpace: 'pre',
+            fontFamily: 'monospace',
+            fontSize: 12,
+            lineHeight: 1.5,
+          }}
+        >
+          {codeLines.join('\n')}
+        </pre>
+      </div>
+    )
+    codeLines = []
+    codeLang = ''
+  }
+
+  for (const rawLine of lines) {
+    const line = rawLine
+    const trimmed = line.trim()
+
+    if (inCode) {
+      if (trimmed.startsWith('```')) {
+        inCode = false
+        flushCode()
+      } else {
+        codeLines.push(line)
+      }
+      continue
+    }
+
+    if (trimmed.startsWith('```')) {
+      flushParagraph()
+      flushList()
+      inCode = true
+      codeLang = trimmed.slice(3).trim()
+      continue
+    }
+
+    const heading = /^(#{1,6})\s+(.*)$/.exec(line)
+    if (heading) {
+      flushParagraph()
+      flushList()
+      const level = heading[1].length
+      const text = heading[2].trim()
+      const fontSize = Math.max(12, 22 - level * 2)
+      elements.push(
+        <div
+          key={`h-${key++}`}
+          style={{ margin: '0 0 10px 0', fontSize, fontWeight: 600, lineHeight: 1.35, color: '#e2dfda' }}
+        >
+          {text}
+        </div>
+      )
+      continue
+    }
+
+    const list = /^\s*[-*+]\s+(.*)$/.exec(line)
+    if (list) {
+      flushParagraph()
+      listItems.push(list[1].trim())
+      continue
+    }
+
+    if (/^\s*>/.test(line)) {
+      flushParagraph()
+      flushList()
+      elements.push(
+        <blockquote
+          key={`q-${key++}`}
+          style={{
+            margin: '0 0 10px 0',
+            borderLeft: '3px solid #3a3a38',
+            padding: '6px 10px',
+            color: '#b7b4af',
+            background: '#141413',
+            borderRadius: 4,
+          }}
+        >
+          {line.replace(/^\s*>\s?/, '')}
+        </blockquote>
+      )
+      continue
+    }
+
+    if (trimmed.length === 0) {
+      flushParagraph()
+      flushList()
+      continue
+    }
+
+    paragraph.push(trimmed)
+  }
+
+  flushParagraph()
+  flushList()
+  if (inCode) flushCode()
+
+  if (elements.length === 0) {
+    elements.push(
+      <p key="empty-md" style={{ margin: 0, color: '#595653' }}>
+        Empty file
+      </p>
+    )
+  }
+
+  return elements
 }
 
 // ── Custom orchid-dark Monaco theme ──────────────────────────────────
@@ -142,55 +335,146 @@ function defineOrchidTheme(monaco: Monaco): void {
   })
 }
 
+function applyEditorAppearance(target: editor.IStandaloneCodeEditor): void {
+  const { appearance } = useSettingsStore.getState().settings
+  target.updateOptions({
+    minimap: { enabled: false },
+    fontSize: appearance.fontSize,
+    lineHeight: Math.round(appearance.fontSize * 1.54),
+    fontFamily: appearance.fontFamily,
+    fontLigatures: true,
+    padding: { top: 8, bottom: 8 },
+    scrollBeyondLastLine: false,
+    renderLineHighlight: 'line',
+    smoothScrolling: true,
+    cursorBlinking: 'smooth',
+    cursorSmoothCaretAnimation: 'on',
+    bracketPairColorization: { enabled: true },
+    guides: { bracketPairs: true, indentation: true },
+    suggest: { showStatusBar: true },
+    wordWrap: 'off',
+    tabSize: 2,
+  })
+}
+
+function modeButtonStyle(active: boolean): CSSProperties {
+  return {
+    border: '1px solid rgba(89,86,83,0.28)',
+    background: active ? '#1f1f1d' : '#121211',
+    color: active ? '#d4d1cb' : '#7f7a75',
+    fontSize: 10,
+    lineHeight: 1,
+    padding: '5px 8px',
+    borderRadius: 5,
+    cursor: 'pointer',
+  }
+}
+
 // ── Component ────────────────────────────────────────────────────────
 
 export function FileEditorPanel() {
   const [filePath, setFilePath] = useState<string | null>(null)
   const [content, setContent] = useState<string>('')
+  const [savedContent, setSavedContent] = useState<string>('')
   const [imagePreviewDataUrl, setImagePreviewDataUrl] = useState<string | null>(null)
+  const [mediaPreviewDataUrl, setMediaPreviewDataUrl] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [fileSize, setFileSize] = useState(0)
   const [isDirty, setIsDirty] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
+  const [isTruncated, setIsTruncated] = useState(false)
+  const [viewMode, setViewMode] = useState<ViewMode>('edit')
+  const [proposalSource, setProposalSource] = useState<ProposalSource | null>(null)
   const [diagnosticCounts, setDiagnosticCounts] = useState({ errors: 0, warnings: 0 })
 
   const monacoRef = useRef<Monaco | null>(null)
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null)
+  const diffEditorRef = useRef<editor.IStandaloneDiffEditor | null>(null)
+  const diffContentListenerRef = useRef<{ dispose: () => void } | null>(null)
   const savedContentRef = useRef<string>('')
+  const pendingProposalRef = useRef<FileUpdateProposal | null>(null)
 
   const fileName = filePath?.split('/').pop() ?? ''
   const lang = filePath ? detectLang(fileName) : 'plaintext'
-  const isImagePreview = filePath ? isImageFile(fileName) : false
-  const fileTypeLabel = isImagePreview ? 'image' : lang
-  const fileTypeColor = isImagePreview ? '#6b8fa3' : langColor(lang)
+  const previewKind = filePath ? detectPreviewKind(fileName) : 'text'
+  const isTextFile = isTextPreviewKind(previewKind)
+  const fileTypeLabel = previewLabel(previewKind, lang)
+  const fileTypeColor = previewColor(previewKind, lang)
+  const canPreviewText = isTextFile
 
-  const { notifyChange } = useLspBridge(filePath, lang, monacoRef, editorRef)
+  const lspPath = isTextFile ? filePath : null
+  const lspLang = isTextFile ? lang : 'plaintext'
+  const { notifyChange } = useLspBridge(lspPath, lspLang, monacoRef, editorRef)
 
-  // Listen for file open events
+  const applyProposalToCurrentFile = useCallback((proposal: FileUpdateProposal) => {
+    setContent(proposal.content)
+    setIsDirty(proposal.content !== savedContentRef.current)
+    setViewMode('diff')
+    setProposalSource(proposal.source ?? 'agent')
+    notifyChange(proposal.content)
+  }, [notifyChange])
+
+  // Listen for file open/proposal events
   useEffect(() => {
-    const handler = (e: Event): void => {
-      const path = (e as CustomEvent<string>).detail
-      if (path) setFilePath(path)
+    const openHandler = (e: Event): void => {
+      const detail = (e as CustomEvent<string | { path: string }>).detail
+      const nextPath = typeof detail === 'string' ? detail : detail?.path
+      if (!nextPath) return
+      pendingProposalRef.current = null
+      setProposalSource(null)
+      setFilePath(nextPath)
     }
-    window.addEventListener('file:open', handler)
-    return () => window.removeEventListener('file:open', handler)
-  }, [])
 
-  // Load file content
+    const proposalHandler = (e: Event): void => {
+      const detail = (e as CustomEvent<FileUpdateProposal>).detail
+      if (!detail?.path || typeof detail.content !== 'string') return
+
+      if (detail.path === filePath) {
+        pendingProposalRef.current = detail
+        if (!isLoading && isTextFile) {
+          pendingProposalRef.current = null
+          applyProposalToCurrentFile(detail)
+        } else if (!isTextFile && !isLoading) {
+          setError('Diff preview is only available for text-like files')
+        }
+        return
+      }
+
+      pendingProposalRef.current = detail
+      setFilePath(detail.path)
+    }
+
+    window.addEventListener('file:open', openHandler)
+    window.addEventListener('file:propose-update', proposalHandler as EventListener)
+    return () => {
+      window.removeEventListener('file:open', openHandler)
+      window.removeEventListener('file:propose-update', proposalHandler as EventListener)
+    }
+  }, [applyProposalToCurrentFile, filePath, isLoading, isTextFile])
+
+  // Load file content/preview
   useEffect(() => {
     if (!filePath) return
     const targetPath = filePath
 
-    const name = targetPath.split('/').pop() ?? ''
     setDiagnosticCounts({ errors: 0, warnings: 0 })
+    setError(null)
+    setIsDirty(false)
+    setIsSaving(false)
+    setIsTruncated(false)
+    setImagePreviewDataUrl(null)
+    setMediaPreviewDataUrl(null)
+    setViewMode(defaultViewMode(previewKind))
+
     let cancelled = false
 
-    if (isImageFile(name)) {
+    if (previewKind === 'image') {
       setIsLoading(true)
-      setError(null)
-      setIsDirty(false)
       setContent('')
+      setSavedContent('')
+      savedContentRef.current = ''
+      setProposalSource(null)
 
       async function loadImagePreview(): Promise<void> {
         try {
@@ -201,7 +485,6 @@ export function FileEditorPanel() {
         } catch (err) {
           if (cancelled) return
           console.error('[FileEditor] Image preview load failed:', err)
-          setImagePreviewDataUrl(null)
           setError(`Failed to preview image: ${err instanceof Error ? err.message : 'unknown'}`)
         } finally {
           if (!cancelled) setIsLoading(false)
@@ -212,26 +495,83 @@ export function FileEditorPanel() {
       return () => { cancelled = true }
     }
 
-    setImagePreviewDataUrl(null)
-    if (isBinary(name)) {
-      setError('Binary file — cannot edit')
+    if (previewKind === 'audio' || previewKind === 'video' || previewKind === 'pdf') {
+      setIsLoading(true)
       setContent('')
-      setFileSize(0)
-      setIsLoading(false)
-      return
+      setSavedContent('')
+      savedContentRef.current = ''
+      setProposalSource(null)
+
+      async function loadMediaPreview(): Promise<void> {
+        try {
+          const result = await window.electronAPI.fs.readDataUrl(targetPath)
+          if (cancelled) return
+          setMediaPreviewDataUrl(result.dataUrl)
+          setFileSize(result.size)
+        } catch (err) {
+          if (cancelled) return
+          console.error('[FileEditor] Media preview load failed:', err)
+          setError(`Failed to preview media: ${err instanceof Error ? err.message : 'unknown'}`)
+        } finally {
+          if (!cancelled) setIsLoading(false)
+        }
+      }
+
+      void loadMediaPreview()
+      return () => { cancelled = true }
+    }
+
+    if (previewKind === 'binary') {
+      setIsLoading(true)
+      setContent('')
+      setSavedContent('')
+      savedContentRef.current = ''
+      setProposalSource(null)
+
+      async function loadBinaryMetadata(): Promise<void> {
+        try {
+          const stat = await window.electronAPI.fs.stat(targetPath)
+          if (cancelled) return
+          setFileSize(stat.size)
+        } catch (err) {
+          if (cancelled) return
+          console.error('[FileEditor] Binary metadata load failed:', err)
+          setError(`Failed to inspect file: ${err instanceof Error ? err.message : 'unknown'}`)
+        } finally {
+          if (!cancelled) setIsLoading(false)
+        }
+      }
+
+      void loadBinaryMetadata()
+      return () => { cancelled = true }
     }
 
     setIsLoading(true)
-    setError(null)
-    setIsDirty(false)
+    setProposalSource(null)
 
-    async function load(): Promise<void> {
+    async function loadTextFile(): Promise<void> {
       try {
         const result = await window.electronAPI.fs.readFile(targetPath)
         if (cancelled) return
-        setContent(result.content)
+
         savedContentRef.current = result.content
+        setSavedContent(result.content)
         setFileSize(result.size)
+        setIsTruncated(result.truncated)
+
+        const pending = pendingProposalRef.current
+        if (pending && pending.path === targetPath) {
+          pendingProposalRef.current = null
+          setContent(pending.content)
+          setIsDirty(pending.content !== result.content)
+          setProposalSource(pending.source ?? 'agent')
+          setViewMode('diff')
+          notifyChange(pending.content)
+        } else {
+          setContent(result.content)
+          setIsDirty(false)
+          setViewMode(defaultViewMode(previewKind))
+        }
       } catch (err) {
         if (cancelled) return
         console.error('[FileEditor] Load failed:', err)
@@ -241,31 +581,53 @@ export function FileEditorPanel() {
       }
     }
 
-    void load()
+    void loadTextFile()
     return () => { cancelled = true }
-  }, [filePath])
+  }, [filePath, previewKind, notifyChange])
 
-  // Save handler
+  // Save handler (staged through diff preview)
   const handleSave = useCallback(async () => {
-    if (!filePath || !editorRef.current || isSaving) return
-    const value = editorRef.current.getValue()
+    if (!filePath || !isTextFile || isSaving) return
+    const nextValue = editorRef.current?.getValue() ?? content
+    if (nextValue === savedContentRef.current) {
+      setIsDirty(false)
+      return
+    }
+
+    if (viewMode !== 'diff') {
+      setViewMode('diff')
+      return
+    }
+
     setIsSaving(true)
     try {
-      await window.electronAPI.fs.writeFile(filePath, value)
-      savedContentRef.current = value
+      await window.electronAPI.fs.writeFile(filePath, nextValue)
+      savedContentRef.current = nextValue
+      setSavedContent(nextValue)
+      setContent(nextValue)
       setIsDirty(false)
+      setProposalSource(null)
+      setViewMode(previewKind === 'markdown' ? 'preview' : 'edit')
     } catch (err) {
       console.error('[FileEditor] Save failed:', err)
+      setError(`Failed to save: ${err instanceof Error ? err.message : 'unknown'}`)
     } finally {
       setIsSaving(false)
     }
-  }, [filePath, isSaving])
+  }, [content, filePath, isSaving, isTextFile, previewKind, viewMode])
 
-  // Listen for Cmd+S
+  const handleDiscardChanges = useCallback(() => {
+    setContent(savedContentRef.current)
+    setIsDirty(false)
+    setProposalSource(null)
+    setViewMode(previewKind === 'markdown' ? 'preview' : 'edit')
+  }, [previewKind])
+
+  // Listen for Cmd/Ctrl+S
   useEffect(() => {
     const handler = (e: KeyboardEvent): void => {
+      if (!isTextFile) return
       if ((e.metaKey || e.ctrlKey) && e.key === 's') {
-        // Only handle if editor is focused
         if (editorRef.current?.hasTextFocus()) {
           e.preventDefault()
           e.stopPropagation()
@@ -275,7 +637,7 @@ export function FileEditorPanel() {
     }
     document.addEventListener('keydown', handler, true)
     return () => document.removeEventListener('keydown', handler, true)
-  }, [handleSave])
+  }, [handleSave, isTextFile])
 
   // Track diagnostic counts from markers
   useEffect(() => {
@@ -297,14 +659,16 @@ export function FileEditorPanel() {
     return () => disposable.dispose()
   }, [])
 
-  const handleEditorMount: OnMount = (editor, monaco) => {
-    editorRef.current = editor
+  const handleEditorMount: OnMount = (editorInstance, monaco) => {
+    editorRef.current = editorInstance
     monacoRef.current = monaco
+    diffEditorRef.current = null
+    diffContentListenerRef.current?.dispose()
+    diffContentListenerRef.current = null
 
     defineOrchidTheme(monaco)
     monaco.editor.setTheme('orchid-dark')
 
-    // Configure TypeScript defaults for JSX/TSX
     monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
       target: monaco.languages.typescript.ScriptTarget.ESNext,
       module: monaco.languages.typescript.ModuleKind.ESNext,
@@ -323,66 +687,274 @@ export function FileEditorPanel() {
       esModuleInterop: true,
     })
 
-    const { appearance } = useSettingsStore.getState().settings
-    editor.updateOptions({
-      minimap: { enabled: false },
-      fontSize: appearance.fontSize,
-      lineHeight: Math.round(appearance.fontSize * 1.54),
-      fontFamily: appearance.fontFamily,
-      fontLigatures: true,
-      padding: { top: 8, bottom: 8 },
-      scrollBeyondLastLine: false,
-      renderLineHighlight: 'line',
-      smoothScrolling: true,
-      cursorBlinking: 'smooth',
-      cursorSmoothCaretAnimation: 'on',
-      bracketPairColorization: { enabled: true },
-      guides: { bracketPairs: true, indentation: true },
-      suggest: { showStatusBar: true },
-      wordWrap: 'off',
-      tabSize: 2,
+    applyEditorAppearance(editorInstance)
+  }
+
+  const handleDiffEditorMount = (diffEditor: editor.IStandaloneDiffEditor, monaco: Monaco): void => {
+    monacoRef.current = monaco
+    diffEditorRef.current = diffEditor
+    const modifiedEditor = diffEditor.getModifiedEditor()
+    editorRef.current = modifiedEditor
+
+    defineOrchidTheme(monaco)
+    monaco.editor.setTheme('orchid-dark')
+
+    applyEditorAppearance(modifiedEditor)
+    applyEditorAppearance(diffEditor.getOriginalEditor())
+
+    diffContentListenerRef.current?.dispose()
+    diffContentListenerRef.current = modifiedEditor.onDidChangeModelContent(() => {
+      const value = modifiedEditor.getValue()
+      setContent(value)
+      setIsDirty(value !== savedContentRef.current)
+      notifyChange(value)
     })
   }
+
+  useEffect(() => {
+    return () => {
+      diffContentListenerRef.current?.dispose()
+      diffContentListenerRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    if (viewMode === 'diff') return
+    diffContentListenerRef.current?.dispose()
+    diffContentListenerRef.current = null
+  }, [viewMode])
 
   // Live-update Monaco when appearance settings change
   useEffect(() => {
     const unsub = useSettingsStore.subscribe((state) => {
-      const ed = editorRef.current
-      if (!ed) return
       const { fontFamily: ff, fontSize: fs } = state.settings.appearance
-      ed.updateOptions({
-        fontSize: fs,
-        lineHeight: Math.round(fs * 1.54),
-        fontFamily: ff,
-      })
+      const modified = editorRef.current
+      if (modified) {
+        modified.updateOptions({
+          fontSize: fs,
+          lineHeight: Math.round(fs * 1.54),
+          fontFamily: ff,
+        })
+      }
+      const diff = diffEditorRef.current
+      if (diff) {
+        diff.getOriginalEditor().updateOptions({
+          fontSize: fs,
+          lineHeight: Math.round(fs * 1.54),
+          fontFamily: ff,
+        })
+      }
     })
     return unsub
   }, [])
 
   const handleEditorChange = useCallback((value: string | undefined) => {
     if (value === undefined) return
+    setContent(value)
     setIsDirty(value !== savedContentRef.current)
     notifyChange(value)
   }, [notifyChange])
+
+  let body: ReactElement
+  if (!filePath) {
+    body = (
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', flexDirection: 'column', gap: 8 }}>
+        <span style={{ fontSize: 24, color: '#3a3a38' }}>◻</span>
+        <span style={{ color: '#595653', fontSize: 12 }}>Open a file to preview or edit</span>
+        <span style={{ color: '#3a3a38', fontSize: 10 }}>Use Explorer or ⌘P to search</span>
+      </div>
+    )
+  } else if (isLoading) {
+    body = <div style={{ padding: 16, color: '#595653', fontSize: 12 }}>Loading...</div>
+  } else if (error) {
+    body = <div style={{ padding: 16, color: '#c45050', fontSize: 12 }}>{error}</div>
+  } else if (previewKind === 'image' && imagePreviewDataUrl) {
+    body = (
+      <div
+        style={{
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 16,
+          backgroundImage: `
+            linear-gradient(45deg, rgba(89,86,83,0.18) 25%, transparent 25%),
+            linear-gradient(-45deg, rgba(89,86,83,0.18) 25%, transparent 25%),
+            linear-gradient(45deg, transparent 75%, rgba(89,86,83,0.18) 75%),
+            linear-gradient(-45deg, transparent 75%, rgba(89,86,83,0.18) 75%)
+          `,
+          backgroundSize: '18px 18px',
+          backgroundPosition: '0 0, 0 9px, 9px -9px, -9px 0px',
+        }}
+      >
+        <img
+          src={imagePreviewDataUrl}
+          alt={fileName}
+          style={{
+            maxWidth: '100%',
+            maxHeight: '100%',
+            objectFit: 'contain',
+            border: '1px solid rgba(89,86,83,0.25)',
+            boxShadow: '0 8px 28px rgba(0,0,0,0.35)',
+            borderRadius: 6,
+          }}
+        />
+      </div>
+    )
+  } else if (previewKind === 'video' && mediaPreviewDataUrl) {
+    body = (
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', padding: 16 }}>
+        <video
+          src={mediaPreviewDataUrl}
+          controls
+          style={{ width: '100%', height: '100%', borderRadius: 8, background: '#000' }}
+        />
+      </div>
+    )
+  } else if (previewKind === 'audio' && mediaPreviewDataUrl) {
+    body = (
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', padding: 16 }}>
+        <audio src={mediaPreviewDataUrl} controls style={{ width: '100%' }} />
+      </div>
+    )
+  } else if (previewKind === 'pdf' && mediaPreviewDataUrl) {
+    body = (
+      <iframe
+        src={mediaPreviewDataUrl}
+        title={fileName}
+        style={{ border: 'none', width: '100%', height: '100%', background: '#0E0E0D' }}
+      />
+    )
+  } else if (previewKind === 'binary') {
+    body = (
+      <div style={{ padding: 16, color: '#9A9692', fontSize: 12, display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <div style={{ color: '#74747C' }}>Binary file preview</div>
+        <div style={{ color: '#595653' }}>Inline rendering is unavailable for this type.</div>
+        <div style={{ color: '#3a3a38', fontSize: 11 }}>Open in external tools to inspect or edit this file.</div>
+      </div>
+    )
+  } else if (isTextFile && viewMode === 'preview') {
+    body = (
+      <div style={{ height: '100%', overflow: 'auto', padding: 14, fontSize: 12, color: '#c9c5bf' }}>
+        {previewKind === 'markdown' ? (
+          <article style={{ maxWidth: 980 }}>{renderMarkdown(content)}</article>
+        ) : (
+          <pre style={{ margin: 0, whiteSpace: 'pre-wrap', lineHeight: 1.5 }}>{content}</pre>
+        )}
+      </div>
+    )
+  } else if (isTextFile && viewMode === 'diff') {
+    body = (
+      <DiffEditor
+        height="100%"
+        language={lang}
+        original={savedContent}
+        modified={content}
+        theme="orchid-dark"
+        onMount={handleDiffEditorMount}
+        options={{
+          readOnly: false,
+          automaticLayout: true,
+          originalEditable: false,
+          renderSideBySide: true,
+          enableSplitViewResizing: true,
+          ignoreTrimWhitespace: false,
+          minimap: { enabled: false },
+        }}
+      />
+    )
+  } else {
+    body = (
+      <Editor
+        height="100%"
+        language={lang}
+        value={content}
+        theme="orchid-dark"
+        onMount={handleEditorMount}
+        onChange={handleEditorChange}
+        options={{
+          readOnly: !isTextFile,
+          automaticLayout: true,
+        }}
+      />
+    )
+  }
+
+  const statusMessage = !filePath
+    ? ''
+    : !isTextFile
+      ? `${fileTypeLabel} preview`
+      : viewMode === 'diff'
+        ? 'Diff preview (⌘/Ctrl+S to apply)'
+        : isDirty
+          ? '⌘/Ctrl+S opens diff'
+          : '⌘/Ctrl+S save'
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%', background: '#0E0E0D', color: '#9A9692' }}>
       {/* Header bar */}
       {filePath && (
         <div style={{
-          display: 'flex', alignItems: 'center', gap: 8, padding: '4px 10px',
-          borderBottom: '1px solid rgba(89,86,83,0.2)', flexShrink: 0, fontSize: 12,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '4px 10px',
+          borderBottom: '1px solid rgba(89,86,83,0.2)',
+          flexShrink: 0,
+          fontSize: 12,
         }}>
           <span style={{ color: '#9A9692', fontWeight: 500 }}>
             {isDirty ? '● ' : ''}{fileName}
           </span>
           <span style={{
-            color: fileTypeColor, fontSize: 10, fontWeight: 600,
-            padding: '1px 6px', background: `${fileTypeColor}15`, borderRadius: 3,
+            color: fileTypeColor,
+            fontSize: 10,
+            fontWeight: 600,
+            padding: '1px 6px',
+            background: `${fileTypeColor}15`,
+            borderRadius: 3,
           }}>
             {fileTypeLabel}
           </span>
+          {isTruncated && (
+            <span style={{ color: '#d4a040', fontSize: 10 }}>truncated</span>
+          )}
+          {proposalSource && (
+            <span style={{ color: '#6b8fa3', fontSize: 10 }}>{proposalSource} proposal</span>
+          )}
           <div style={{ flex: 1 }} />
+
+          {isTextFile && (
+            <>
+              <button
+                type="button"
+                style={modeButtonStyle(viewMode === 'edit')}
+                onClick={() => setViewMode('edit')}
+                title="Edit mode"
+              >
+                Edit
+              </button>
+              {canPreviewText && (
+                <button
+                  type="button"
+                  style={modeButtonStyle(viewMode === 'preview')}
+                  onClick={() => setViewMode('preview')}
+                  title="Preview mode"
+                >
+                  Preview
+                </button>
+              )}
+              <button
+                type="button"
+                style={modeButtonStyle(viewMode === 'diff')}
+                onClick={() => setViewMode('diff')}
+                title="Diff preview"
+              >
+                Diff
+              </button>
+            </>
+          )}
+
           {diagnosticCounts.errors > 0 && (
             <span style={{ color: '#c45050', fontSize: 10 }}>
               ✕ {diagnosticCounts.errors}
@@ -396,82 +968,53 @@ export function FileEditorPanel() {
           {fileSize > 0 && (
             <span style={{ color: '#3a3a38', fontSize: 10 }}>{formatSize(fileSize)}</span>
           )}
-          {isSaving && (
-            <span style={{ color: '#548C5A', fontSize: 10 }}>saving...</span>
+
+          {isTextFile && (
+            <>
+              {isDirty && (
+                <button
+                  type="button"
+                  style={modeButtonStyle(false)}
+                  onClick={handleDiscardChanges}
+                  title="Discard unsaved changes"
+                >
+                  Discard
+                </button>
+              )}
+              <button
+                type="button"
+                style={modeButtonStyle(false)}
+                onClick={() => { void handleSave() }}
+                title={viewMode === 'diff' ? 'Apply changes' : 'Review diff before save'}
+              >
+                {isSaving ? 'Saving...' : viewMode === 'diff' ? 'Apply' : 'Review'}
+              </button>
+            </>
           )}
         </div>
       )}
 
-      {/* Editor area */}
+      {/* Editor/preview area */}
       <div style={{ flex: 1, minHeight: 0 }}>
-        {!filePath ? (
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', flexDirection: 'column', gap: 8 }}>
-            <span style={{ fontSize: 24, color: '#3a3a38' }}>◻</span>
-            <span style={{ color: '#595653', fontSize: 12 }}>Open a file to edit</span>
-            <span style={{ color: '#3a3a38', fontSize: 10 }}>Use Explorer or ⌘P to search</span>
-          </div>
-        ) : isLoading ? (
-          <div style={{ padding: 16, color: '#595653', fontSize: 12 }}>Loading...</div>
-        ) : imagePreviewDataUrl ? (
-          <div
-            style={{
-              height: '100%',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              padding: 16,
-              backgroundImage: `
-                linear-gradient(45deg, rgba(89,86,83,0.18) 25%, transparent 25%),
-                linear-gradient(-45deg, rgba(89,86,83,0.18) 25%, transparent 25%),
-                linear-gradient(45deg, transparent 75%, rgba(89,86,83,0.18) 75%),
-                linear-gradient(-45deg, transparent 75%, rgba(89,86,83,0.18) 75%)
-              `,
-              backgroundSize: '18px 18px',
-              backgroundPosition: '0 0, 0 9px, 9px -9px, -9px 0px',
-            }}
-          >
-            <img
-              src={imagePreviewDataUrl}
-              alt={fileName}
-              style={{
-                maxWidth: '100%',
-                maxHeight: '100%',
-                objectFit: 'contain',
-                border: '1px solid rgba(89,86,83,0.25)',
-                boxShadow: '0 8px 28px rgba(0,0,0,0.35)',
-                borderRadius: 6,
-              }}
-            />
-          </div>
-        ) : error ? (
-          <div style={{ padding: 16, color: '#c45050', fontSize: 12 }}>{error}</div>
-        ) : (
-          <Editor
-            height="100%"
-            language={lang}
-            value={content}
-            theme="orchid-dark"
-            onMount={handleEditorMount}
-            onChange={handleEditorChange}
-            options={{
-              readOnly: false,
-              automaticLayout: true,
-            }}
-          />
-        )}
+        {body}
       </div>
 
       {/* Status bar */}
       {filePath && (
         <div style={{
-          display: 'flex', alignItems: 'center', gap: 12,
-          padding: '2px 10px', borderTop: '1px solid rgba(89,86,83,0.2)',
-          fontSize: 10, color: '#3a3a38', flexShrink: 0,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          padding: '2px 10px',
+          borderTop: '1px solid rgba(89,86,83,0.2)',
+          fontSize: 10,
+          color: '#3a3a38',
+          flexShrink: 0,
         }}>
           <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>
             {filePath}
           </span>
-          <span>{imagePreviewDataUrl ? 'Image preview' : '⌘S save'}</span>
+          <span>{statusMessage}</span>
         </div>
       )}
     </div>

--- a/src/shared/electron-api.ts
+++ b/src/shared/electron-api.ts
@@ -36,6 +36,7 @@ export const IPC_CHANNELS = {
     readDir: 'fs:readDir',
     readFile: 'fs:readFile',
     readImageDataUrl: 'fs:readImageDataUrl',
+    readDataUrl: 'fs:readDataUrl',
     search: 'fs:search',
     homeDir: 'fs:homeDir',
     stat: 'fs:stat',
@@ -116,6 +117,12 @@ export interface FsReadFileResult {
 }
 
 export interface FsReadImageDataUrlResult {
+  dataUrl: string
+  size: number
+  mimeType: string
+}
+
+export interface FsReadDataUrlResult {
   dataUrl: string
   size: number
   mimeType: string
@@ -221,6 +228,7 @@ export interface ElectronAPI {
     readDir: (dirPath: string, showHidden?: boolean) => Promise<FsEntry[]>
     readFile: (filePath: string) => Promise<FsReadFileResult>
     readImageDataUrl: (filePath: string) => Promise<FsReadImageDataUrlResult>
+    readDataUrl: (filePath: string) => Promise<FsReadDataUrlResult>
     search: (rootDir: string, query: string, maxResults?: number) => Promise<FsSearchResult[]>
     homeDir: () => Promise<string>
     stat: (filePath: string) => Promise<FsStatResult>


### PR DESCRIPTION
## Summary
- add generic `fs.readDataUrl` IPC to preview non-text assets (audio/video/PDF) in the desktop editor panel
- refactor `FileEditorPanel` to support preview modes for text/markdown/image/audio/video/PDF with binary metadata fallback
- add staged text save flow: edit -> diff preview -> apply/discard (including `Cmd/Ctrl+S` behavior)
- add `file:propose-update` event handling so agent/user proposals can open directly in diff mode
- update docs/changelog highlights for the new explorer preview + diff behavior

## Validation
- pnpm lint
- pnpm typecheck

## Follow-up
- Tracking issue for semantic diff support on non-text binary formats: #154

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core desktop editing UX and introduces new IPC-based file preview paths (including base64 data URLs), which could impact performance/memory and change save semantics if edge cases aren’t covered.
> 
> **Overview**
> Enables Explorer-opened files to render in `FileEditorPanel` as **text/markdown/image/audio/video/PDF previews**, falling back to a binary metadata view for non-renderable types.
> 
> Introduces a **staged save workflow for text-like files** (edit/preview/diff modes): `⌘/Ctrl+S` and the header actions now open a diff review first, then apply/discard changes; markdown defaults to preview mode and large files surface a *truncated* indicator.
> 
> Extends the Electron filesystem bridge with a generic `fs:readDataUrl` IPC (and MIME mapping) to support audio/video/PDF previews, and adds `file:propose-update` event handling so agent/user proposals can open directly in diff mode. Updates `README`/`CHANGELOG` highlights accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f295a2f2ad3b7c1bc7e7353e3786591cfd83dec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->