### PR TITLE
test: stabilize ubuntu coverage run

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "package": "electron-vite build && electron-builder --mac --dir",
     "package:dmg": "electron-vite build && electron-builder --mac dmg",
     "test:smoke": "pnpm build && playwright test -c playwright.smoke.config.ts",
-    "test:coverage": "pnpm exec c8 --report-dir coverage --reporter=text-summary --reporter=lcov --reporter=json-summary playwright test -c playwright.smoke.config.ts --grep-invert \"desktop smoke flows\"",
+    "test:coverage": "pnpm exec c8 --report-dir coverage --reporter=text-summary --reporter=lcov --reporter=json-summary playwright test -c playwright.smoke.config.ts --grep-invert \"desktop smoke flows|managed shell timeout terminates descendant process trees\"",
     "postinstall": "electron-rebuild -f -w node-pty",
     "prepare": "husky"
   },


### PR DESCRIPTION
## Summary
- stabilize `test:coverage` on Ubuntu by excluding the timing-sensitive process-tree stress spec from the coverage run
- keep the coverage workflow focused on deterministic non-Electron smoke coverage while CI continues to validate that stress case in the main smoke suite

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:coverage`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes test selection for the coverage command; no production code or runtime behavior is affected.
> 
> **Overview**
> Adjusts the `test:coverage` npm script in `package.json` to also `--grep-invert` the timing-sensitive Playwright test named `managed shell timeout terminates descendant process trees`, keeping coverage runs more deterministic while leaving the full smoke suite unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f82420bd29ff1bbb9fa84f8151c48d6de867706. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->