### PR TITLE
docs: clarify required ruleset check names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,7 @@ pnpm lint:web
 pnpm typecheck
 pnpm build
 pnpm -C web build
+pnpm test:coverage
 ```
 
 If your change touches desktop behavior, also run:
@@ -68,6 +69,14 @@ If your change touches desktop behavior, also run:
 ```bash
 pnpm test:smoke
 ```
+
+Ruleset required checks (exact GitHub check names):
+
+- `Desktop Lint, Typecheck, Build`
+- `Frontend Lint, Typecheck, Build`
+- `Smoke Coverage (non-Electron)`
+- `Smoke Scope`
+- `Desktop Smoke (Electron)`
 
 ## Commit and PR Guidelines
 


### PR DESCRIPTION
## Summary
- update contributor docs with the exact GitHub check names to require in rulesets
- add `pnpm test:coverage` to the required local pre-PR command list

## Validation
- `pnpm lint`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adjusts contributor workflow guidance; no runtime or production code paths are affected.
> 
> **Overview**
> Updates `CONTRIBUTING.md` to add `pnpm test:coverage` to the pre-PR required local commands.
> 
> Also documents the *exact* GitHub ruleset required check names (desktop/frontend build checks and smoke/coverage checks) to reduce ambiguity when configuring repository rulesets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f06aa541ac50126bc864d345d84a07a82cc2ab61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->