### PR TITLE
feat: show startup update notice for outdated app versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   text-like edits.
 - Added a dedicated GitHub Actions test-coverage workflow that runs non-Electron
   smoke tests under `c8` and publishes coverage artifacts/summary.
+- App now checks GitHub releases on startup and shows an in-app update banner
+  when a newer version is available.
 
 ### Changed
 

--- a/src/main/app-updates.ts
+++ b/src/main/app-updates.ts
@@ -1,0 +1,143 @@
+import { app, ipcMain } from 'electron'
+import { IPC_CHANNELS, type AppUpdateStatusResult } from '../shared/electron-api'
+
+const RELEASE_API_URL = 'https://api.github.com/repos/webrenew/agent-observer/releases/latest'
+const RELEASE_FALLBACK_URL = 'https://github.com/webrenew/agent-observer/releases/latest'
+const UPDATE_CHECK_TIMEOUT_MS = 7_000
+const UPDATE_CHECK_CACHE_MS = 30 * 60 * 1_000
+
+let handlersRegistered = false
+let cachedStatus: AppUpdateStatusResult | null = null
+let cacheTimestampMs = 0
+let pendingStatusPromise: Promise<AppUpdateStatusResult> | null = null
+
+function parseSemverTriplet(version: string): [number, number, number] | null {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)/i.exec(version.trim())
+  if (!match) return null
+
+  const major = Number.parseInt(match[1] ?? '', 10)
+  const minor = Number.parseInt(match[2] ?? '', 10)
+  const patch = Number.parseInt(match[3] ?? '', 10)
+  if (![major, minor, patch].every((value) => Number.isFinite(value))) return null
+  return [major, minor, patch]
+}
+
+export function __testOnlyCompareSemver(left: string, right: string): number {
+  const leftParts = parseSemverTriplet(left)
+  const rightParts = parseSemverTriplet(right)
+  if (!leftParts || !rightParts) return 0
+
+  if (leftParts[0] !== rightParts[0]) return leftParts[0] - rightParts[0]
+  if (leftParts[1] !== rightParts[1]) return leftParts[1] - rightParts[1]
+  return leftParts[2] - rightParts[2]
+}
+
+export function __testOnlyIsUpdateAvailable(currentVersion: string, latestVersion: string): boolean {
+  return __testOnlyCompareSemver(latestVersion, currentVersion) > 0
+}
+
+function baseStatus(currentVersion: string): AppUpdateStatusResult {
+  return {
+    currentVersion,
+    latestVersion: null,
+    updateAvailable: false,
+    releaseUrl: RELEASE_FALLBACK_URL,
+    checkedAt: Date.now(),
+    error: null,
+  }
+}
+
+async function fetchLatestRelease(): Promise<{ latestVersion: string; releaseUrl: string }> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), UPDATE_CHECK_TIMEOUT_MS)
+
+  try {
+    const response = await fetch(RELEASE_API_URL, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'User-Agent': `agent-observer/${app.getVersion()}`,
+      },
+      signal: controller.signal,
+    })
+
+    if (!response.ok) {
+      throw new Error(`Update check failed with status ${response.status}`)
+    }
+
+    const payload = (await response.json()) as { tag_name?: unknown; html_url?: unknown }
+    if (typeof payload.tag_name !== 'string' || payload.tag_name.trim().length === 0) {
+      throw new Error('Release payload missing tag_name')
+    }
+
+    const releaseUrl = typeof payload.html_url === 'string' && payload.html_url.startsWith('http')
+      ? payload.html_url
+      : RELEASE_FALLBACK_URL
+
+    return {
+      latestVersion: payload.tag_name.trim(),
+      releaseUrl,
+    }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+function normalizeUpdateError(err: unknown): string {
+  if (err instanceof DOMException && err.name === 'AbortError') {
+    return 'Update check timed out'
+  }
+  if (err instanceof Error) return err.message
+  return String(err)
+}
+
+async function checkForUpdates(): Promise<AppUpdateStatusResult> {
+  const currentVersion = app.getVersion()
+  const fallback = baseStatus(currentVersion)
+
+  try {
+    const latest = await fetchLatestRelease()
+    return {
+      ...fallback,
+      latestVersion: latest.latestVersion,
+      releaseUrl: latest.releaseUrl,
+      updateAvailable: __testOnlyIsUpdateAvailable(currentVersion, latest.latestVersion),
+      checkedAt: Date.now(),
+    }
+  } catch (err) {
+    return {
+      ...fallback,
+      error: normalizeUpdateError(err),
+      checkedAt: Date.now(),
+    }
+  }
+}
+
+async function resolveUpdateStatus(): Promise<AppUpdateStatusResult> {
+  const now = Date.now()
+  if (cachedStatus && (now - cacheTimestampMs) < UPDATE_CHECK_CACHE_MS) {
+    return cachedStatus
+  }
+
+  if (pendingStatusPromise) return pendingStatusPromise
+
+  pendingStatusPromise = checkForUpdates()
+    .then((status) => {
+      cachedStatus = status
+      cacheTimestampMs = Date.now()
+      return status
+    })
+    .finally(() => {
+      pendingStatusPromise = null
+    })
+
+  return pendingStatusPromise
+}
+
+export function setupUpdateHandlers(): void {
+  if (handlersRegistered) return
+  handlersRegistered = true
+
+  ipcMain.handle(IPC_CHANNELS.updates.getStatus, async () => {
+    return resolveUpdateStatus()
+  })
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,7 @@ import { setupAgentNamerHandlers } from './agent-namer'
 import { setupSchedulerHandlers, cleanupScheduler } from './scheduler'
 import { setupTodoRunnerHandlers, cleanupTodoRunner } from './todo-runner'
 import { setupWorkspaceContextHandlers } from './workspace-context'
+import { setupUpdateHandlers } from './app-updates'
 import {
   addStartupBreadcrumb,
   flushStartupBreadcrumbs,
@@ -423,6 +424,7 @@ if (!gotTheLock) {
     flushStartupBreadcrumbs()
     runStartupStep('filesystem_handlers', () => setupFilesystemHandlers(mainWindow!))
     runStartupStep('workspace_context_handlers', () => setupWorkspaceContextHandlers())
+    runStartupStep('update_handlers', () => setupUpdateHandlers())
     runStartupStep('lsp_handlers', () => setupLspHandlers(mainWindow!))
     runStartupStep('memories_handlers', () => setupMemoriesHandlers())
     runStartupStep('agent_namer_handlers', () => setupAgentNamerHandlers(mainWindow!))

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -142,6 +142,9 @@ const electronAPI: ElectronAPI = {
       IPC_CHANNELS.context.getWorkspaceSnapshot
     ),
   },
+  updates: {
+    getStatus: invokeFor<ElectronAPI['updates']['getStatus']>(IPC_CHANNELS.updates.getStatus),
+  },
   scheduler: {
     list: invokeFor<ElectronAPI['scheduler']['list']>(IPC_CHANNELS.scheduler.list),
     upsert: invokeFor<ElectronAPI['scheduler']['upsert']>(IPC_CHANNELS.scheduler.upsert),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,10 +1,11 @@
-import { useEffect, lazy, Suspense } from 'react'
+import { useEffect, lazy, Suspense, useMemo, useState } from 'react'
 import { WorkspaceLayout } from './components/workspace/WorkspaceLayout'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { FirstRunOnboarding } from './components/FirstRunOnboarding'
 import { useSettingsStore, loadSettings } from './store/settings'
 import { useWorkspaceStore } from './store/workspace'
 import { syncPluginCatalogFromProfiles } from './plugins/runtime'
+import type { AppUpdateStatusResult } from '../shared/electron-api'
 
 const LazySettingsPanel = lazy(async () => {
   const mod = await import('./components/SettingsPanel')
@@ -16,6 +17,12 @@ const LazyHelpPanel = lazy(async () => {
   return { default: mod.HelpPanel }
 })
 
+const UPDATE_DISMISS_KEY_PREFIX = 'agent-observer:update-dismissed:'
+
+function dismissKeyFor(latestVersion: string): string {
+  return `${UPDATE_DISMISS_KEY_PREFIX}${latestVersion}`
+}
+
 export function App() {
   const openSettings = useSettingsStore((s) => s.openSettings)
   const openHelp = useSettingsStore((s) => s.openHelp)
@@ -24,6 +31,7 @@ export function App() {
   const fontFamily = useSettingsStore((s) => s.settings.appearance.fontFamily)
   const fontSize = useSettingsStore((s) => s.settings.appearance.fontSize)
   const claudeProfiles = useSettingsStore((s) => s.settings.claudeProfiles)
+  const [updateNotice, setUpdateNotice] = useState<AppUpdateStatusResult | null>(null)
 
   useEffect(() => {
     void (async () => {
@@ -54,11 +62,100 @@ export function App() {
     void syncPluginCatalogFromProfiles(claudeProfiles)
   }, [claudeProfiles])
 
+  useEffect(() => {
+    let cancelled = false
+
+    void (async () => {
+      try {
+        const status = await window.electronAPI.updates.getStatus()
+        if (cancelled || !status.updateAvailable || !status.latestVersion) return
+
+        const dismissed = localStorage.getItem(dismissKeyFor(status.latestVersion)) === 'dismissed'
+        if (dismissed) return
+
+        setUpdateNotice(status)
+      } catch (err) {
+        console.warn('[App] update status check failed:', err)
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const updateDownloadUrl = useMemo(() => (
+    updateNotice?.releaseUrl || 'https://github.com/webrenew/agent-observer/releases/latest'
+  ), [updateNotice?.releaseUrl])
+
+  const dismissUpdateNotice = () => {
+    if (updateNotice?.latestVersion) {
+      localStorage.setItem(dismissKeyFor(updateNotice.latestVersion), 'dismissed')
+    }
+    setUpdateNotice(null)
+  }
+
   return (
-    <div className="w-full h-full">
-      <ErrorBoundary fallbackLabel="WorkspaceLayout">
-        <WorkspaceLayout />
-      </ErrorBoundary>
+    <div className="w-full h-full" style={{ display: 'flex', flexDirection: 'column' }}>
+      {updateNotice && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            padding: '7px 12px',
+            borderBottom: '1px solid rgba(84, 140, 90, 0.35)',
+            background: 'linear-gradient(90deg, #121613 0%, #141B16 100%)',
+            color: '#d8dfd3',
+            fontSize: 12,
+            lineHeight: 1.4,
+            flexShrink: 0,
+          }}
+        >
+          <span style={{ fontWeight: 600 }}>Update available</span>
+          <span style={{ color: '#aeb7a6' }}>
+            v{(updateNotice.latestVersion ?? '').replace(/^v/i, '')}
+            {' '}is available (current v{updateNotice.currentVersion.replace(/^v/i, '')}).
+          </span>
+          <div style={{ flex: 1 }} />
+          <button
+            type="button"
+            onClick={() => window.open(updateDownloadUrl, '_blank', 'noopener,noreferrer')}
+            style={{
+              border: '1px solid rgba(84, 140, 90, 0.5)',
+              background: '#1E2920',
+              color: '#d8dfd3',
+              borderRadius: 5,
+              fontSize: 11,
+              padding: '4px 8px',
+              cursor: 'pointer',
+            }}
+          >
+            Update
+          </button>
+          <button
+            type="button"
+            onClick={dismissUpdateNotice}
+            style={{
+              border: '1px solid rgba(89, 86, 83, 0.4)',
+              background: '#121211',
+              color: '#9A9692',
+              borderRadius: 5,
+              fontSize: 11,
+              padding: '4px 8px',
+              cursor: 'pointer',
+            }}
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      <div style={{ flex: 1, minHeight: 0 }}>
+        <ErrorBoundary fallbackLabel="WorkspaceLayout">
+          <WorkspaceLayout />
+        </ErrorBoundary>
+      </div>
       {isSettingsOpen ? (
         <Suspense fallback={null}>
           <LazySettingsPanel />

--- a/src/shared/electron-api.ts
+++ b/src/shared/electron-api.ts
@@ -82,6 +82,9 @@ export const IPC_CHANNELS = {
   context: {
     getWorkspaceSnapshot: 'context:getWorkspaceSnapshot',
   },
+  updates: {
+    getStatus: 'updates:getStatus',
+  },
   scheduler: {
     list: 'scheduler:list',
     upsert: 'scheduler:upsert',
@@ -198,6 +201,15 @@ export interface TodoRunnerPauseResult {
   stopOutcome: TodoRunnerStopOutcome
 }
 
+export interface AppUpdateStatusResult {
+  currentVersion: string
+  latestVersion: string | null
+  updateAvailable: boolean
+  releaseUrl: string
+  checkedAt: number
+  error: string | null
+}
+
 export interface ElectronAPI {
   versions: {
     node: string
@@ -277,6 +289,9 @@ export interface ElectronAPI {
   }
   context: {
     getWorkspaceSnapshot: (directory: string) => Promise<WorkspaceContextSnapshot>
+  }
+  updates: {
+    getStatus: () => Promise<AppUpdateStatusResult>
   }
   scheduler: {
     list: () => Promise<SchedulerTask[]>

--- a/tests/smoke/app-updates.spec.ts
+++ b/tests/smoke/app-updates.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test'
+import {
+  __testOnlyCompareSemver,
+  __testOnlyIsUpdateAvailable,
+} from '../../src/main/app-updates'
+
+test('semver comparison handles v-prefix and major/minor/patch ordering', () => {
+  expect(__testOnlyCompareSemver('v1.2.3', '1.2.3')).toBe(0)
+  expect(__testOnlyCompareSemver('1.2.4', '1.2.3')).toBeGreaterThan(0)
+  expect(__testOnlyCompareSemver('1.3.0', '1.2.99')).toBeGreaterThan(0)
+  expect(__testOnlyCompareSemver('2.0.0', '1.99.99')).toBeGreaterThan(0)
+  expect(__testOnlyCompareSemver('1.1.9', '1.2.0')).toBeLessThan(0)
+})
+
+test('semver comparison tolerates prerelease/build suffixes', () => {
+  expect(__testOnlyCompareSemver('v1.2.3-beta.1', '1.2.3')).toBe(0)
+  expect(__testOnlyCompareSemver('1.2.3+build.9', 'v1.2.3')).toBe(0)
+  expect(__testOnlyCompareSemver('1.2.4-rc.1', '1.2.3')).toBeGreaterThan(0)
+})
+
+test('update availability is true only when latest is newer than current', () => {
+  expect(__testOnlyIsUpdateAvailable('1.1.0', '1.1.1')).toBe(true)
+  expect(__testOnlyIsUpdateAvailable('1.2.0', '1.2.0')).toBe(false)
+  expect(__testOnlyIsUpdateAvailable('1.3.0', '1.2.9')).toBe(false)
+  expect(__testOnlyIsUpdateAvailable('not-semver', '1.2.0')).toBe(false)
+  expect(__testOnlyIsUpdateAvailable('1.2.0', 'not-semver')).toBe(false)
+})


### PR DESCRIPTION
## Summary
- add an `updates:getStatus` IPC endpoint with cached GitHub latest-release checks in the Electron main process
- expose update status through preload/shared API so renderer can query startup update state
- add a dismissible startup banner in `App.tsx` when a newer desktop version is available, with a direct update link
- add smoke unit tests for semver/update-availability logic in `app-updates`
- update changelog with the new startup update notification behavior

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec playwright test -c playwright.smoke.config.ts tests/smoke/app-updates.spec.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new network call on startup (GitHub API) and new IPC surface area; failures are handled, but regressions could impact startup UX/performance or IPC stability.
> 
> **Overview**
> Adds an Electron main-process update checker (`updates:getStatus`) that fetches the latest GitHub release with timeout handling and 30-minute caching, then exposes the result through the shared/preload `electronAPI`.
> 
> On renderer startup, `App.tsx` now queries this status and shows a dismissible in-app update banner linking to the release page when a newer version is available (persisting dismiss state in `localStorage`). Smoke tests cover semver comparison/update-available logic, and the changelog is updated to note the new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7873c3ea511af407ebe9082c9631ce3494d2430f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->