### PR TITLE
fix: allow unsigned installer release builds

### DIFF
--- a/.github/workflows/release-desktop-installer.yml
+++ b/.github/workflows/release-desktop-installer.yml
@@ -113,7 +113,15 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: pnpm exec electron-vite build && pnpm exec electron-builder --mac dmg --publish never
+        run: |
+          set -euo pipefail
+          pnpm exec electron-vite build
+          if [ -n "${CSC_LINK:-}" ]; then
+            pnpm exec electron-builder --mac dmg --publish never
+          else
+            echo "CSC_LINK is not configured; building an unsigned macOS DMG."
+            CSC_IDENTITY_AUTO_DISCOVERY=false pnpm exec electron-builder --mac dmg --publish never -c.mac.identity=-
+          fi
 
       - name: Verify installer artifact
         run: |


### PR DESCRIPTION
Allows the release installer workflow to build an unsigned DMG when code signing secrets are not configured. This unblocks the v1.3.3 release asset upload while preserving the signed path when CSC_LINK is present.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/webrenew/codesmith/agent-observer/pr/261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782693567&installation_id=129242532&pr_number=261&repository=webrenew%2Fagent-observer&return_to=https%3A%2F%2Fgithub.com%2Fwebrenew%2Fagent-observer%2Fpull%2F261&signature=9ff2bd189b3caecabc4f3427b23e76b763bc4f39f71870109af76d2951e56961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->